### PR TITLE
change "impure" function to match description

### DIFF
--- a/src/page/blog/PolymorphicEffects.js
+++ b/src/page/blog/PolymorphicEffects.js
@@ -241,8 +241,8 @@ class PolymorphicEffects extends Component {
                         </InlineEditor>
 
                         <p>
-                            The signature <code>f: b ~> Bool</code> denotes an impure function
-                            from <code>b</code> to <code>Unit</code>. Passing a pure function to <code>foreach</code> is
+                            The signature <code>f: a ~> Unit</code> denotes an impure function
+                            from <code>a</code> to <code>Unit</code>. Passing a pure function to <code>foreach</code> is
                             a compile-time type error. Given that <code>f</code> is impure and <code>f</code> is called
                             within <code>foreach</code>, it is itself impure. We enforce that
                             the <code>f</code> function is impure because it is pointless to apply


### PR DESCRIPTION
change "impure" `b ~> Bool` function to `a ~> Unit` to match the signature in the `foreach` function above it and the description after it.

Please forgive me if I've missed something, but as I was reading it seemed the wording should match the edits I've made instead of what is there currently. If there is a different way I should submit this issue, let me know. Thank you! I'm extremely excited about Flix!

