### PR TITLE
refactor: update record member type ascription syntax

### DIFF
--- a/src/data/Samples.js
+++ b/src/data/Samples.js
@@ -91,7 +91,7 @@ def main(): Unit \\ IO =
             name: "Record Construction and Use",
             code: `/// Returns the area of the rectangle \`r\`.
 /// The record \`r\` must have \`x\` and \`y\` labels, and no other labels.
-def area(r: {x :: Int32, y :: Int32}): Int32 = r.x * r.y
+def area(r: {x = Int32, y = Int32}): Int32 = r.x * r.y
 
 /// Computes the area of various rectangle records.
 /// Note that the order of labels is immaterial.
@@ -102,7 +102,7 @@ def areas(): List[Int32] =
 /// Returns the area of the polymorphic record \`r\`.
 /// Note that the use of the type variable \`a\` permits the record \`r\`
 /// to have labels other than \`x\` and \`y\`.
-def polyArea(r : {x :: Int32, y :: Int32 | a}): Int32 = r.x * r.y
+def polyArea(r : {x = Int32, y = Int32 | a}): Int32 = r.x * r.y
 
 /// Computes the area of various rectangle records.
 /// Note that some records have additional fields.
@@ -117,7 +117,7 @@ def main(): Unit \\ IO =
         {
             name: "Polymorphic Record Update",
             code: `/// Returns the record \`r\` with a new value of its \`x\` label.
-def setX(r: {x :: Int32, y :: Int32}, v: Int32): {x :: Int32, y :: Int32} =
+def setX(r: {x = Int32, y = Int32}, v: Int32): {x = Int32, y = Int32} =
     { x = v | r }
 
 /// Returns the value 1 + 3 = 4.
@@ -128,7 +128,7 @@ def main2(): Int32 =
 
 /// Returns the record \`r\` with a new value of its \`y\` label.
 /// Preserves (retains) all other labels polymorphically.
-def setY(r: {y :: Int32 | a}, v: Int32): {y :: Int32 | a} =
+def setY(r: {y = Int32 | a}, v: Int32): {y = Int32 | a} =
     { y = v | r }
 
 /// Returns the value 0 + 1 + 3 = 4.
@@ -143,12 +143,12 @@ def main(): Unit \\ IO =
             name: "Polymorphic Record Extension and Restriction",
             code: `/// Polymorphically extends the record \`r\` with an \`age\` label.
 /// Preserves (retains) all other labels polymorphically.
-def withAge(r: {| a}, v: Int32): {age :: Int32 | a} =
+def withAge(r: {| a}, v: Int32): {age = Int32 | a} =
     { +age = v | r }
 
 /// Polymorphically restricts (removes) the \`age\` label from \`r\`.
 /// Preserves (retains) all other labels polymorphically.
-def withoutAge(r: {age :: Int32 | a}): {| a} = {-age | r}
+def withoutAge(r: {age = Int32 | a}): {| a} = {-age | r}
 
 /// Construct several records and extend them with an age.
 def main(): Unit \\ IO =

--- a/src/page/Home.js
+++ b/src/page/Home.js
@@ -175,11 +175,11 @@ def area(s: Shape): Int32 = match s {
                         <InlineEditor>
                             {`def origin(): (Int32, Int32) = (0, 0)
 
-def oneByOne():  {w :: Int32, h :: Int32} = {w = 1, h = 1}
+def oneByOne():  {w = Int32, h = Int32} = {w = 1, h = 1}
 
-def twoByFour(): {w :: Int32, h :: Int32} = {w = 2, h = 4}
+def twoByFour(): {w = Int32, h = Int32} = {w = 2, h = 4}
 
-def area(rect: {w :: Int32, h :: Int32 | r}): Int32 =
+def area(rect: {w = Int32, h = Int32 | r}): Int32 =
     rect.w * rect.h
 
 def f(): Int32 = area({h = 1, color = "Blue", w = 2})`}

--- a/src/page/Koans.js
+++ b/src/page/Koans.js
@@ -107,7 +107,7 @@ class Koans extends Component {
                         </h5>
 
                         <InlineEditor>
-                            {`pub def heirsAndUsurpers(parents: Array[(person, person)], emperors: Array[person]): {heirs :: Array[person], usurpers :: Array[person]} with Boxable[person] =
+                            {`pub def heirsAndUsurpers(parents: Array[(person, person)], emperors: Array[person]): {heirs = Array[person], usurpers = Array[person]} with Boxable[person] =
     let p = project parents into Parent;
     let e = project emperors into Emperor;
     let lp = #{
@@ -153,7 +153,7 @@ class Koans extends Component {
                         </p>
 
                         <InlineEditor>
-                            {`pub def orphansAndZombies(processes: Array[(processId, String, processId)], rootId: processId): {orphans :: Array[processId], zombies :: Array[processId]} with Boxable[processId] =
+                            {`pub def orphansAndZombies(processes: Array[(processId, String, processId)], rootId: processId): {orphans = Array[processId], zombies = Array[processId]} with Boxable[processId] =
     let p = project processes into Process;
     let lp = #{
         Zombie(pid) :- Process(pid, "dead", parent), Process(parent, "alive", _).


### PR DESCRIPTION
Updates the syntax for record member type ascription. From `::` to `=` as per https://github.com/flix/flix/pull/4526