### PR TITLE
feat: update/add "open source contributors" links.

### DIFF
--- a/src/page/Contribute.js
+++ b/src/page/Contribute.js
@@ -19,7 +19,8 @@ class Contribute extends Component {
                             Flix is developed at <a
                             href="http://cs.au.dk/research/programming-languages/">Aarhus
                             University</a>, at the <a href="http://plg.uwaterloo.ca"> University of Waterloo</a>, and by
-                            a community of open source contributors.
+                            a community of <a href="https://github.com/flix/flix/graphs/contributors">open source
+                            contributors</a>.
                         </p>
 
                         <p>

--- a/src/page/Home.js
+++ b/src/page/Home.js
@@ -59,7 +59,7 @@ class Home extends Component {
                             Flix is a principled functional, imperative, and logic programming language
                             developed at <a href="https://cs.au.dk/">Aarhus University</a>, at the <a
                             href="https://uwaterloo.ca/">University of Waterloo</a>, and by a community of <a
-                            href="https://github.com/flix/flix">open source contributors</a>.
+                            href="https://github.com/flix/flix/graphs/contributors">open source contributors</a>.
                         </p>
 
                         <p className="text-justify">


### PR DESCRIPTION
`Home.js`'s link now points to the contributors. Added a link to `Contribute.js` to match `Home.js`.
I can understand if `Home.js` should remain pointing to `github.com/flix/flix` to have two ways to navigate to the repo (the other is the "Fork me on Github" top right hand banner which doesn't actually link to https://github.com/flix/flix/fork). However, `Contribute.js` has a link to GitHub, so at the very least, leaving this page linking directly to the community of open source  contributors makes sense.