### PR TITLE
fix: GitHub ribbon URL

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -15,7 +15,7 @@
 
 <a href="https://github.com/flix/flix">
     <img style="position: absolute; top: 0; right: 0; border: 0; z-index: 9999;"
-         src="https://s3.amazonaws.com/github/ribbons/forkme_right_green_007200.png"
+         src="https://github.blog/wp-content/uploads/2008/12/forkme_right_green_007200.png"
          alt="Fork me on GitHub">
 </a>
 


### PR DESCRIPTION
Closes #96