### PR TITLE
feat: make boxes clickable links

### DIFF
--- a/src/page/Documentation.js
+++ b/src/page/Documentation.js
@@ -36,7 +36,7 @@ class Documentation extends Component {
                                 <CardTitle className="text-center">
                                     Programming Flix
                                 </CardTitle>
-                                <CardText style={{ color: 'rgb(33, 37, 41)' }}>
+                                <CardText className="text-reset">
                                     The book provides an introduction to Flix for functional programmers. The book
                                     demonstrates the core concepts of Flix through several examples.
                                 </CardText>
@@ -75,7 +75,7 @@ class Documentation extends Component {
                                 <CardSubtitle className="text-center m-4">
                                     <MdSchool style={{ fontSize: '3em' }} />
                                 </CardSubtitle>
-                                <CardTitle className="text-center" style={{ color: 'rgb(0, 123, 255)' }}>
+                                <CardTitle className="text-center text-primary">
                                     Research Papers
                                 </CardTitle>
                             </Card>
@@ -88,7 +88,7 @@ class Documentation extends Component {
                                 <CardSubtitle className="text-center m-4">
                                     <FaMicroblog style={{ fontSize: '3em' }} />
                                 </CardSubtitle>
-                                <CardTitle className="text-center" style={{ color: 'rgb(0, 123, 255)' }}>
+                                <CardTitle className="text-center text-primary">
                                     Blog
                                 </CardTitle>
                             </Card>
@@ -101,7 +101,7 @@ class Documentation extends Component {
                                 <CardSubtitle className="text-center m-4">
                                     <FaGitter style={{ fontSize: '3em' }} />
                                 </CardSubtitle>
-                                <CardTitle className="text-center" style={{ color: 'rgb(0, 123, 255)' }}>
+                                <CardTitle className="text-center text-primary">
                                     Gitter
                                 </CardTitle>
                             </Card>
@@ -114,7 +114,7 @@ class Documentation extends Component {
                                 <CardSubtitle className="text-center m-4">
                                     <FaGithub style={{ fontSize: '3em' }} />
                                 </CardSubtitle>
-                                <CardTitle className="text-center" style={{ color: 'rgb(0, 123, 255)' }}>
+                                <CardTitle className="text-center text-primary">
                                     GitHub
                                 </CardTitle>
                             </Card>
@@ -127,7 +127,7 @@ class Documentation extends Component {
                                 <CardSubtitle className="text-center m-4">
                                     <GoGraph style={{ fontSize: '3em' }} />
                                 </CardSubtitle>
-                                <CardTitle className="text-center" style={{ color: 'rgb(0, 123, 255)' }}>
+                                <CardTitle className="text-center text-primary">
                                     Compiler Perf
                                 </CardTitle>
                             </Card>
@@ -140,7 +140,7 @@ class Documentation extends Component {
                                 <CardSubtitle className="text-center m-4">
                                     <FaRegLaughSquint style={{ fontSize: '3em' }} />
                                 </CardSubtitle>
-                                <CardTitle className="text-center text-decoration-none">
+                                <CardTitle className="text-center text-primary">
                                     Language Checklist
                                 </CardTitle>
                             </Card>

--- a/src/page/Documentation.js
+++ b/src/page/Documentation.js
@@ -28,15 +28,15 @@ class Documentation extends Component {
 
                 <Row className="mb-4">
                     <Col md="6">
-                        <a href="https://doc.flix.dev/" className="text-primary">
+                        <a href="https://doc.flix.dev/" className="text-reset">
                             <Card body className="h-100">
-                                <CardSubtitle className="text-center m-4">
+                                <CardSubtitle className="text-center m-4 text-primary">
                                     <FaBookReader style={{ fontSize: '6em' }} />
                                 </CardSubtitle>
-                                <CardTitle className="text-center">
+                                <CardTitle className="text-center text-primary">
                                     Programming Flix
                                 </CardTitle>
-                                <CardText className="text-reset">
+                                <CardText>
                                     The book provides an introduction to Flix for functional programmers. The book
                                     demonstrates the core concepts of Flix through several examples.
                                 </CardText>
@@ -44,15 +44,15 @@ class Documentation extends Component {
                         </a>
                     </Col>
                     <Col md="6">
-                        <a href="https://api.flix.dev/" className="text-success">
+                        <a href="https://api.flix.dev/" className="text-reset">
                             <Card body className="h-100">
-                                <CardSubtitle className="text-center m-4">
+                                <CardSubtitle className="text-center m-4 text-success">
                                     <FaStream style={{ fontSize: '6em' }} />
                                 </CardSubtitle>
-                                <CardTitle className="text-center">
+                                <CardTitle className="text-center text-success">
                                     Standard Library
                                 </CardTitle>
-                                <CardText className="text-reset">
+                                <CardText>
                                     The documentation provides a Javadoc-style description of the Flix library.
                                 </CardText>
                             </Card>

--- a/src/page/Documentation.js
+++ b/src/page/Documentation.js
@@ -140,7 +140,7 @@ class Documentation extends Component {
                                 <CardSubtitle className="text-center m-4">
                                     <FaRegLaughSquint style={{ fontSize: '3em' }} />
                                 </CardSubtitle>
-                                <CardTitle className="text-center" style={{ color: 'rgb(0, 123, 255)' }}>
+                                <CardTitle className="text-center text-link">
                                     Language Checklist
                                 </CardTitle>
                             </Card>

--- a/src/page/Documentation.js
+++ b/src/page/Documentation.js
@@ -52,7 +52,7 @@ class Documentation extends Component {
                                 <CardTitle className="text-center">
                                     Standard Library
                                 </CardTitle>
-                                <CardText>
+                                <CardText style="color: blue">
                                     The documentation provides a Javadoc-style description of the Flix library.
                                 </CardText>
                             </Card>

--- a/src/page/Documentation.js
+++ b/src/page/Documentation.js
@@ -1,15 +1,15 @@
-import React, {Component} from 'react';
-import {Card, CardSubtitle, CardText, CardTitle, Col, Container, Row} from "reactstrap";
-import {Link} from "react-router-dom";
+import React, { Component } from 'react';
+import { Card, CardSubtitle, CardText, CardTitle, Col, Container, Row } from "reactstrap";
+import { Link } from "react-router-dom";
 
-import {FaBookReader} from 'react-icons/fa';
-import {FaStream} from 'react-icons/fa';
-import {FaMicroblog} from 'react-icons/fa';
-import {FaGitter} from 'react-icons/fa';
-import {FaGithub} from 'react-icons/fa';
-import {FaRegLaughSquint} from 'react-icons/fa';
-import {MdSchool} from 'react-icons/md';
-import {GoGraph} from 'react-icons/go';
+import { FaBookReader } from 'react-icons/fa';
+import { FaStream } from 'react-icons/fa';
+import { FaMicroblog } from 'react-icons/fa';
+import { FaGitter } from 'react-icons/fa';
+import { FaGithub } from 'react-icons/fa';
+import { FaRegLaughSquint } from 'react-icons/fa';
+import { MdSchool } from 'react-icons/md';
+import { GoGraph } from 'react-icons/go';
 
 class Documentation extends Component {
 
@@ -28,37 +28,35 @@ class Documentation extends Component {
 
                 <Row className="mb-4">
                     <Col md="6">
-                        <Card body className="h-100">
-                            <CardSubtitle className="text-center m-4">
-                                <a href="https://doc.flix.dev/" className="text-primary">
-                                    <FaBookReader style={{fontSize: '6em'}}/>
-                                </a>
-                            </CardSubtitle>
-                            <CardTitle className="text-center">
-                                <a href="https://doc.flix.dev/">Programming Flix</a>
-                            </CardTitle>
-                            <CardText>
-                                The book provides an introduction to Flix for functional programmers. The book
-                                demonstrates the core concepts of Flix through several examples.
-                            </CardText>
-                        </Card>
+                        <a href="https://doc.flix.dev/" className="text-primary">
+                            <Card body className="h-100">
+                                <CardSubtitle className="text-center m-4">
+                                    <FaBookReader style={{ fontSize: '6em' }} />
+                                </CardSubtitle>
+                                <CardTitle className="text-center">
+                                    Programming Flix
+                                </CardTitle>
+                                <CardText>
+                                    The book provides an introduction to Flix for functional programmers. The book
+                                    demonstrates the core concepts of Flix through several examples.
+                                </CardText>
+                            </Card>
+                        </a>
                     </Col>
                     <Col md="6">
-                        <Card body className="h-100">
-                            <CardSubtitle className="text-center m-4">
-                                <a href="https://api.flix.dev/" className="text-success">
-                                    <FaStream style={{fontSize: '6em'}}/>
-                                </a>
-                            </CardSubtitle>
-                            <CardTitle className="text-center">
-                                <a href="https://api.flix.dev/">
+                        <a href="https://api.flix.dev/" className="text-success">
+                            <Card body className="h-100">
+                                <CardSubtitle className="text-center m-4">
+                                    <FaStream style={{ fontSize: '6em' }} />
+                                </CardSubtitle>
+                                <CardTitle className="text-center">
                                     Standard Library
-                                </a>
-                            </CardTitle>
-                            <CardText>
-                                The documentation provides a Javadoc-style description of the Flix library.
-                            </CardText>
-                        </Card>
+                                </CardTitle>
+                                <CardText>
+                                    The documentation provides a Javadoc-style description of the Flix library.
+                                </CardText>
+                            </Card>
+                        </a>
                     </Col>
                 </Row>
 
@@ -72,81 +70,81 @@ class Documentation extends Component {
 
                 <Row className="mb-3">
                     <Col lg="2">
-                        <Card body className="h-100">
-                            <CardSubtitle className="text-center m-4">
-                                <Link to="/research" className="text-black-50">
-                                    <MdSchool style={{fontSize: '3em'}}/>
-                                </Link>
-                            </CardSubtitle>
-                            <CardTitle className="text-center">
-                                <Link to="/research"> Research Papers </Link>
-                            </CardTitle>
-                        </Card>
+                        <Link to="/research" className="text-black-50">
+                            <Card body className="h-100">
+                                <CardSubtitle className="text-center m-4">
+                                    <MdSchool style={{ fontSize: '3em' }} />
+                                </CardSubtitle>
+                                <CardTitle className="text-center">
+                                    Research Papers
+                                </CardTitle>
+                            </Card>
+                        </Link>
                     </Col>
 
                     <Col lg="2">
-                        <Card body className="h-100">
-                            <CardSubtitle className="text-center m-4">
-                                <Link to="/blog/" className="text-black-50">
-                                    <FaMicroblog style={{fontSize: '3em'}}/>
-                                </Link>
-                            </CardSubtitle>
-                            <CardTitle className="text-center">
-                                <Link to="/blog/"> Blog </Link>
-                            </CardTitle>
-                        </Card>
+                        <Link to="/blog/" className="text-black-50">
+                            <Card body className="h-100">
+                                <CardSubtitle className="text-center m-4">
+                                    <FaMicroblog style={{ fontSize: '3em' }} />
+                                </CardSubtitle>
+                                <CardTitle className="text-center">
+                                    Blog
+                                </CardTitle>
+                            </Card>
+                        </Link>
                     </Col>
 
                     <Col lg="2">
-                        <Card body className="h-100">
-                            <CardSubtitle className="text-center m-4">
-                                <a href="https://gitter.im/flix/Lobby" className="text-black-50">
-                                    <FaGitter style={{fontSize: '3em'}}/>
-                                </a>
-                            </CardSubtitle>
-                            <CardTitle className="text-center">
-                                <a href="https://gitter.im/flix/Lobby"> Gitter </a>
-                            </CardTitle>
-                        </Card>
+                        <a href="https://gitter.im/flix/Lobby" className="text-black-50">
+                            <Card body className="h-100">
+                                <CardSubtitle className="text-center m-4">
+                                    <FaGitter style={{ fontSize: '3em' }} />
+                                </CardSubtitle>
+                                <CardTitle className="text-center">
+                                    Gitter
+                                </CardTitle>
+                            </Card>
+                        </a>
                     </Col>
 
                     <Col lg="2">
-                        <Card body className="h-100">
-                            <CardSubtitle className="text-center m-4">
-                                <a href="https://github.com/flix/flix" className="text-black-50">
-                                    <FaGithub style={{fontSize: '3em'}}/>
-                                </a>
-                            </CardSubtitle>
-                            <CardTitle className="text-center">
-                                <a href="https://github.com/flix/flix"> GitHub </a>
-                            </CardTitle>
-                        </Card>
+                        <a href="https://github.com/flix/flix" className="text-black-50">
+                            <Card body className="h-100">
+                                <CardSubtitle className="text-center m-4">
+                                    <FaGithub style={{ fontSize: '3em' }} />
+                                </CardSubtitle>
+                                <CardTitle className="text-center">
+                                    GitHub
+                                </CardTitle>
+                            </Card>
+                        </a>
                     </Col>
 
                     <Col lg="2">
-                        <Card body className="h-100">
-                            <CardSubtitle className="text-center m-4">
-                                <a href="https://arewefast.flix.dev/" className="text-black-50">
-                                    <GoGraph style={{fontSize: '3em'}}/>
-                                </a>
-                            </CardSubtitle>
-                            <CardTitle className="text-center">
-                                <a href="https://arewefast.flix.dev/"> Compiler Perf </a>
-                            </CardTitle>
-                        </Card>
+                        <a href="https://arewefast.flix.dev/" className="text-black-50">
+                            <Card body className="h-100">
+                                <CardSubtitle className="text-center m-4">
+                                    <GoGraph style={{ fontSize: '3em' }} />
+                                </CardSubtitle>
+                                <CardTitle className="text-center">
+                                    Compiler Perf
+                                </CardTitle>
+                            </Card>
+                        </a>
                     </Col>
 
                     <Col lg="2">
-                        <Card body className="h-100">
-                            <CardSubtitle className="text-center m-4">
-                                <Link to="/misc/checklist" className="text-black-50">
-                                    <FaRegLaughSquint style={{fontSize: '3em'}}/>
-                                </Link>
-                            </CardSubtitle>
-                            <CardTitle className="text-center">
-                                <Link to="/misc/checklist"> Language Checklist </Link>
-                            </CardTitle>
-                        </Card>
+                        <Link to="/misc/checklist" className="text-black-50">
+                            <Card body className="h-100">
+                                <CardSubtitle className="text-center m-4">
+                                    <FaRegLaughSquint style={{ fontSize: '3em' }} />
+                                </CardSubtitle>
+                                <CardTitle className="text-center">
+                                    Language Checklist
+                                </CardTitle>
+                            </Card>
+                        </Link>
                     </Col>
                 </Row>
             </Container>

--- a/src/page/Documentation.js
+++ b/src/page/Documentation.js
@@ -36,7 +36,7 @@ class Documentation extends Component {
                                 <CardTitle className="text-center">
                                     Programming Flix
                                 </CardTitle>
-                                <CardText>
+                                <CardText style={{ color: 'rgb(33, 37, 41)' }}>
                                     The book provides an introduction to Flix for functional programmers. The book
                                     demonstrates the core concepts of Flix through several examples.
                                 </CardText>
@@ -52,7 +52,7 @@ class Documentation extends Component {
                                 <CardTitle className="text-center">
                                     Standard Library
                                 </CardTitle>
-                                <CardText>
+                                <CardText style={{ color: 'rgb(33, 37, 41)' }}>
                                     The documentation provides a Javadoc-style description of the Flix library.
                                 </CardText>
                             </Card>
@@ -75,7 +75,7 @@ class Documentation extends Component {
                                 <CardSubtitle className="text-center m-4">
                                     <MdSchool style={{ fontSize: '3em' }} />
                                 </CardSubtitle>
-                                <CardTitle className="text-center">
+                                <CardTitle className="text-center" style={{ color: 'rgb(0, 123, 255)' }}>
                                     Research Papers
                                 </CardTitle>
                             </Card>
@@ -88,7 +88,7 @@ class Documentation extends Component {
                                 <CardSubtitle className="text-center m-4">
                                     <FaMicroblog style={{ fontSize: '3em' }} />
                                 </CardSubtitle>
-                                <CardTitle className="text-center">
+                                <CardTitle className="text-center" style={{ color: 'rgb(0, 123, 255)' }}>
                                     Blog
                                 </CardTitle>
                             </Card>
@@ -101,7 +101,7 @@ class Documentation extends Component {
                                 <CardSubtitle className="text-center m-4">
                                     <FaGitter style={{ fontSize: '3em' }} />
                                 </CardSubtitle>
-                                <CardTitle className="text-center">
+                                <CardTitle className="text-center" style={{ color: 'rgb(0, 123, 255)' }}>
                                     Gitter
                                 </CardTitle>
                             </Card>
@@ -114,7 +114,7 @@ class Documentation extends Component {
                                 <CardSubtitle className="text-center m-4">
                                     <FaGithub style={{ fontSize: '3em' }} />
                                 </CardSubtitle>
-                                <CardTitle className="text-center">
+                                <CardTitle className="text-center" style={{ color: 'rgb(0, 123, 255)' }}>
                                     GitHub
                                 </CardTitle>
                             </Card>
@@ -127,7 +127,7 @@ class Documentation extends Component {
                                 <CardSubtitle className="text-center m-4">
                                     <GoGraph style={{ fontSize: '3em' }} />
                                 </CardSubtitle>
-                                <CardTitle className="text-center">
+                                <CardTitle className="text-center" style={{ color: 'rgb(0, 123, 255)' }}>
                                     Compiler Perf
                                 </CardTitle>
                             </Card>
@@ -140,7 +140,7 @@ class Documentation extends Component {
                                 <CardSubtitle className="text-center m-4">
                                     <FaRegLaughSquint style={{ fontSize: '3em' }} />
                                 </CardSubtitle>
-                                <CardTitle className="text-center">
+                                <CardTitle className="text-center" style={{ color: 'rgb(0, 123, 255)' }}>
                                     Language Checklist
                                 </CardTitle>
                             </Card>

--- a/src/page/Documentation.js
+++ b/src/page/Documentation.js
@@ -140,7 +140,7 @@ class Documentation extends Component {
                                 <CardSubtitle className="text-center m-4">
                                     <FaRegLaughSquint style={{ fontSize: '3em' }} />
                                 </CardSubtitle>
-                                <CardTitle className="text-center text-decoration-none text-link">
+                                <CardTitle className="text-center text-decoration-none">
                                     Language Checklist
                                 </CardTitle>
                             </Card>

--- a/src/page/Documentation.js
+++ b/src/page/Documentation.js
@@ -52,7 +52,7 @@ class Documentation extends Component {
                                 <CardTitle className="text-center">
                                     Standard Library
                                 </CardTitle>
-                                <CardText style="color: blue">
+                                <CardText>
                                     The documentation provides a Javadoc-style description of the Flix library.
                                 </CardText>
                             </Card>

--- a/src/page/Documentation.js
+++ b/src/page/Documentation.js
@@ -52,7 +52,7 @@ class Documentation extends Component {
                                 <CardTitle className="text-center">
                                     Standard Library
                                 </CardTitle>
-                                <CardText style={{ color: 'rgb(33, 37, 41)' }}>
+                                <CardText className="text-reset">
                                     The documentation provides a Javadoc-style description of the Flix library.
                                 </CardText>
                             </Card>
@@ -140,7 +140,7 @@ class Documentation extends Component {
                                 <CardSubtitle className="text-center m-4">
                                     <FaRegLaughSquint style={{ fontSize: '3em' }} />
                                 </CardSubtitle>
-                                <CardTitle className="text-center text-link">
+                                <CardTitle className="text-center text-decoration-none text-link">
                                     Language Checklist
                                 </CardTitle>
                             </Card>

--- a/src/page/Documentation.js
+++ b/src/page/Documentation.js
@@ -28,15 +28,15 @@ class Documentation extends Component {
 
                 <Row className="mb-4">
                     <Col md="6">
-                        <a href="https://doc.flix.dev/" className="text-reset">
+                        <a href="https://doc.flix.dev/" className="text-primary">
                             <Card body className="h-100">
-                                <CardSubtitle className="text-center m-4 text-primary">
+                                <CardSubtitle className="text-center m-4">
                                     <FaBookReader style={{ fontSize: '6em' }} />
                                 </CardSubtitle>
-                                <CardTitle className="text-center text-primary">
+                                <CardTitle className="text-center">
                                     Programming Flix
                                 </CardTitle>
-                                <CardText>
+                                <CardText className="text-dark">
                                     The book provides an introduction to Flix for functional programmers. The book
                                     demonstrates the core concepts of Flix through several examples.
                                 </CardText>
@@ -44,15 +44,15 @@ class Documentation extends Component {
                         </a>
                     </Col>
                     <Col md="6">
-                        <a href="https://api.flix.dev/" className="text-reset">
+                        <a href="https://api.flix.dev/" className="text-success">
                             <Card body className="h-100">
-                                <CardSubtitle className="text-center m-4 text-success">
+                                <CardSubtitle className="text-center m-4">
                                     <FaStream style={{ fontSize: '6em' }} />
                                 </CardSubtitle>
-                                <CardTitle className="text-center text-success">
+                                <CardTitle className="text-center">
                                     Standard Library
                                 </CardTitle>
-                                <CardText>
+                                <CardText className="text-dark">
                                     The documentation provides a Javadoc-style description of the Flix library.
                                 </CardText>
                             </Card>
@@ -70,12 +70,12 @@ class Documentation extends Component {
 
                 <Row className="mb-3">
                     <Col lg="2">
-                        <Link to="/research" className="text-black-50">
+                        <Link to="/research">
                             <Card body className="h-100">
-                                <CardSubtitle className="text-center m-4">
+                                <CardSubtitle className="text-center m-4 text-black-50">
                                     <MdSchool style={{ fontSize: '3em' }} />
                                 </CardSubtitle>
-                                <CardTitle className="text-center text-primary">
+                                <CardTitle className="text-center link-primary">
                                     Research Papers
                                 </CardTitle>
                             </Card>
@@ -83,12 +83,12 @@ class Documentation extends Component {
                     </Col>
 
                     <Col lg="2">
-                        <Link to="/blog/" className="text-black-50">
+                        <Link to="/blog/">
                             <Card body className="h-100">
-                                <CardSubtitle className="text-center m-4">
+                                <CardSubtitle className="text-center m-4 text-black-50">
                                     <FaMicroblog style={{ fontSize: '3em' }} />
                                 </CardSubtitle>
-                                <CardTitle className="text-center text-primary">
+                                <CardTitle className="text-center link-primary">
                                     Blog
                                 </CardTitle>
                             </Card>
@@ -96,12 +96,12 @@ class Documentation extends Component {
                     </Col>
 
                     <Col lg="2">
-                        <a href="https://gitter.im/flix/Lobby" className="text-black-50">
+                        <a href="https://gitter.im/flix/Lobby">
                             <Card body className="h-100">
-                                <CardSubtitle className="text-center m-4">
+                                <CardSubtitle className="text-center m-4 text-black-50">
                                     <FaGitter style={{ fontSize: '3em' }} />
                                 </CardSubtitle>
-                                <CardTitle className="text-center text-primary">
+                                <CardTitle className="text-center link-primary">
                                     Gitter
                                 </CardTitle>
                             </Card>
@@ -109,12 +109,12 @@ class Documentation extends Component {
                     </Col>
 
                     <Col lg="2">
-                        <a href="https://github.com/flix/flix" className="text-black-50">
+                        <a href="https://github.com/flix/flix">
                             <Card body className="h-100">
-                                <CardSubtitle className="text-center m-4">
+                                <CardSubtitle className="text-center m-4 text-black-50">
                                     <FaGithub style={{ fontSize: '3em' }} />
                                 </CardSubtitle>
-                                <CardTitle className="text-center text-primary">
+                                <CardTitle className="text-center link-primary">
                                     GitHub
                                 </CardTitle>
                             </Card>
@@ -122,12 +122,12 @@ class Documentation extends Component {
                     </Col>
 
                     <Col lg="2">
-                        <a href="https://arewefast.flix.dev/" className="text-black-50">
+                        <a href="https://arewefast.flix.dev/">
                             <Card body className="h-100">
-                                <CardSubtitle className="text-center m-4">
+                                <CardSubtitle className="text-center m-4 text-black-50">
                                     <GoGraph style={{ fontSize: '3em' }} />
                                 </CardSubtitle>
-                                <CardTitle className="text-center text-primary">
+                                <CardTitle className="text-center link-primary">
                                     Compiler Perf
                                 </CardTitle>
                             </Card>
@@ -135,12 +135,12 @@ class Documentation extends Component {
                     </Col>
 
                     <Col lg="2">
-                        <Link to="/misc/checklist" className="text-black-50">
+                        <Link to="/misc/checklist">
                             <Card body className="h-100">
-                                <CardSubtitle className="text-center m-4">
+                                <CardSubtitle className="text-center m-4 text-black-50">
                                     <FaRegLaughSquint style={{ fontSize: '3em' }} />
                                 </CardSubtitle>
-                                <CardTitle className="text-center text-primary">
+                                <CardTitle className="text-center link-primary">
                                     Language Checklist
                                 </CardTitle>
                             </Card>


### PR DESCRIPTION
I think the boxes on the documentation page should be clickable links. It's just annoying that you have to *think* about how click a link.