### PR TITLE
chore: remove 'Print a Colorful Message' example

### DIFF
--- a/build-scripts/sampleFiles.mjs
+++ b/build-scripts/sampleFiles.mjs
@@ -102,10 +102,6 @@ export const sampleFiles = [
         file: "working-with-files-and-directories.flix",
     },
     {
-        name: "Print a Colorful Message",
-        file: "print-a-colorful-message.flix",
-    },
-    {
         name: "Using Laziness for Infinite Streams",
         file: "using-laziness-for-infinite-streams.flix",
     },


### PR DESCRIPTION
The colors aren't displayed correctly on the site:

![image](https://github.com/flix/flix.dev/assets/61235930/e4f2d71c-10d6-4678-a4a9-d038aa028038)
