### PR TITLE
refactor: migrate chat references from Gitter to Zulip

### DIFF
--- a/src/page/Contribute.jsx
+++ b/src/page/Contribute.jsx
@@ -32,7 +32,7 @@ function Contribute() {
 
                             We organize development using <a
                             href="https://github.com/flix/flix/issues">GitHub issues</a> and <a
-                            href="https://gitter.im/flix/Lobby">Gitter</a>.
+                            href="https://flix.zulipchat.com/">Zulip</a>.
                         </p>
 
                         <p>

--- a/src/page/Documentation.jsx
+++ b/src/page/Documentation.jsx
@@ -5,7 +5,7 @@ import {Link} from "react-router-dom";
 import {FaBookReader} from 'react-icons/fa';
 import {FaStream} from 'react-icons/fa';
 import {FaMicroblog} from 'react-icons/fa';
-import {FaGitter} from 'react-icons/fa';
+import {SiZulip} from 'react-icons/si';
 import {FaGithub} from 'react-icons/fa';
 import {FaTwitter} from 'react-icons/fa';
 import {GoGraph} from 'react-icons/go';
@@ -97,13 +97,13 @@ function Documentation() {
                     </Col>
 
                     <Col lg="2">
-                        <a href="https://gitter.im/flix/Lobby">
+                        <a href="https://flix.zulipchat.com/">
                             <Card body className="h-100">
                                 <CardSubtitle className="text-center m-4 text-black-50">
-                                    <FaGitter style={{fontSize: '3em'}}/>
+                                    <SiZulip style={{fontSize: '3em'}}/>
                                 </CardSubtitle>
                                 <CardTitle className="text-center link-primary">
-                                    Gitter
+                                    Zulip
                                 </CardTitle>
                             </Card>
                         </a>

--- a/src/page/Faq.jsx
+++ b/src/page/Faq.jsx
@@ -27,7 +27,7 @@ function Faq() {
 
                         <p>
                             If you get stuck or need help feel free to reach out to
-                            us on <a href="https://gitter.im/flix/Lobby">Gitter</a>.
+                            us on <a href="https://flix.zulipchat.com/">Zulip</a>.
                         </p>
                     </Answer>
                 </QA>
@@ -59,7 +59,7 @@ function Faq() {
                         Yes! We welcome any contributions and we are happy to mentor someone who wants to work
                         on the compiler. We are also open to general feedback and discussion about the language
                         design. Head on over to <a href="https://github.com/flix/flix">GitHub</a> or <a
-                        href="https://gitter.im/flix/Lobby">Gitter</a> and reach out to us!
+                        href="https://flix.zulipchat.com/">Zulip</a> and reach out to us!
                     </Answer>
                 </QA>
 
@@ -223,7 +223,7 @@ function Faq() {
                     </Question>
                     <Answer>
                         We are always happy to learn! We are ready to discuss design choices made in Flix.
-                        Swing by Gitter or on GitHub.
+                        Swing by <a href="https://flix.zulipchat.com/">Zulip</a> or on GitHub.
                     </Answer>
                 </QA>
 

--- a/src/page/Internships.jsx
+++ b/src/page/Internships.jsx
@@ -51,7 +51,7 @@ function Internships() {
 
                     <p>
                         If you have questions, feel free to head over to <a
-                        href="https://gitter.im/flix/Lobby">Gitter</a> and talk to us.
+                        href="https://flix.zulipchat.com/">Zulip</a> and talk to us.
                     </p>
 
                     <hr/>


### PR DESCRIPTION
## Summary
- Replace all Gitter links (`https://gitter.im/flix/Lobby`) with Zulip (`https://flix.zulipchat.com/`) across Contribute, Documentation, FAQ, and Internships pages
- Update the Documentation page icon from `FaGitter` to `SiZulip` (from `react-icons/si`)
- Convert a previously plain-text "Gitter" mention in FAQ into a proper Zulip link

## Test plan
- [x] Verify all Zulip links resolve to `https://flix.zulipchat.com/`
- [x] Verify the Zulip icon renders correctly on the Documentation page
- [x] Confirm no remaining Gitter references in the codebase

🤖 Generated with [Claude Code](https://claude.com/claude-code)