### PR TITLE
fix: invalid h4 font-size and CSS cleanup

### DIFF
--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -7,19 +7,20 @@ body {
 h1 {
     font-size: 2rem;
     margin-bottom: 0.75rem;
-    text-align: left;
 }
 
 h2 {
     font-size: 1.7rem;
     margin-bottom: 0.75rem;
-    text-align: left;
 }
 
 h3 {
     font-size: 1.6rem;
     margin-bottom: 0.75rem;
-    text-align: left;
+}
+
+h4 {
+    font-size: 1.5rem;
 }
 
 p:last-child {
@@ -49,15 +50,15 @@ p:last-child {
     padding: 1em 1.75em;
     background-color: #f7f7f7;
     overflow-x: auto;
+}
 
-    pre,
-    code {
-      font-size: 12px;
-      font-family:
+.inline-editor-code pre,
+.inline-editor-code code {
+    font-size: 12px;
+    font-family:
         Monaco, Menlo, "Ubuntu Mono", Consolas, "Source Code Pro",
         source-code-pro, monospace;
-      line-height: 16px;
-    }
+    line-height: 16px;
 }
 
 .inline-editor-code pre {
@@ -79,14 +80,6 @@ p:last-child {
 
 .card-title {
     font-size: 1.2rem;
-}
-
-h4 {
-    font-size: 1.5 rem;
-}
-
-.w-33 {
-    width: 33%;
 }
 
 .carousel-caption {


### PR DESCRIPTION
## Summary
- Fix `font-size: 1.5 rem` on `h4` — the space between number and unit made the declaration invalid CSS, so browsers dropped it and `h4` fell back to the default size. Now `1.5rem` applies as intended.
- Flatten the `pre, code` rule nested inside `.inline-editor-code` to a plain descendant selector, matching the flat style of the rest of the file (identical output).
- Remove the `.w-33` rule (referenced nowhere in `src/`) and the redundant `text-align: left` on `h1`–`h3`.
- Move the `h4` rule next to the other heading rules so the heading scale reads in one place.

The only visible change is `h4` headings now rendering at the intended 1.5rem; everything else is behavior-preserving cleanup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)