### PR TITLE
refactor: update outdated and non-https links

### DIFF
--- a/src/pages/contribute.astro
+++ b/src/pages/contribute.astro
@@ -10,7 +10,7 @@ import Layout from "../layouts/Layout.astro";
 
         <p>
           Flix is developed at <a
-            href="http://cs.au.dk/research/programming-languages/"
+            href="https://cs.au.dk/research/programming-languages-logic-and-software-security"
             >Aarhus University</a
           >, at the <a href="http://plg.uwaterloo.ca">University of Waterloo</a
           >, and by a community of <a

--- a/src/pages/documentation.astro
+++ b/src/pages/documentation.astro
@@ -13,7 +13,7 @@ const smallLinks = [
   },
   {
     text: "Blog",
-    link: "/blog/",
+    link: "https://blog.flix.dev/",
     icon: "fa-brands:microblog",
   },
   {
@@ -28,7 +28,7 @@ const smallLinks = [
   },
   {
     text: "Twitter",
-    link: "https://twitter.com/flixlang",
+    link: "https://x.com/flixlang",
     icon: "fa-brands:twitter",
   },
   {

--- a/src/pages/principles.astro
+++ b/src/pages/principles.astro
@@ -226,7 +226,7 @@ import Principle from "../components/Principle.astro"
         </Principle>
 
         <Principle name="Share memory by communicating">
-            Flix follows the Go mantra: <a href="https://blog.golang.org/share-memory-by-communicating"><i>Do
+            Flix follows the Go mantra: <a href="https://go.dev/blog/codelab-share"><i>Do
             not communicate by sharing memory; instead, share memory by
             communicating.</i></a> In other words: mutable memory should never be shared between processes.
             Processes should only share immutable messages (and data structures). We believe this
@@ -235,7 +235,7 @@ import Principle from "../components/Principle.astro"
         </Principle>
 
         <Principle name="Bugs are not recoverable errors">
-            We believe in the <a href="http://joeduffyblog.com/2016/02/07/the-error-model/">Midori Error
+            We believe in the <a href="https://joeduffyblog.com/2016/02/07/the-error-model/">Midori Error
             Model</a>; that is, there are two kinds of errors: <i>recoverable errors</i> and <i>program
             bugs</i>. Recoverable errors are things like illegal user input, network errors, etc. Errors
             that can be anticipated and where there is a chance of recovery. Program bugs, on the other


### PR DESCRIPTION
## Summary
Audited every external link in `src/` (55 unique URLs) and fixed the ones that were outdated or broken:

- **Documentation page**: the Blog card now links directly to `https://blog.flix.dev/` (instead of routing through the `/blog/` interstitial page), and the Twitter card now points to `https://x.com/flixlang`.
- **Contribute page**: the Aarhus University link now points to the research group's current page, `https://cs.au.dk/research/programming-languages-logic-and-software-security` (the old URL returns 404).
- **Principles page**: the Go blog article moved to `https://go.dev/blog/codelab-share` (`blog.golang.org` no longer responds); the Joe Duffy blog link is upgraded to https.

## Known remaining issues (out of scope)
- `http://plg.uwaterloo.ca` (Contribute page) is unreachable — the Waterloo PLG site appears to be gone; needs a decision on a replacement.
- The two Benchmarks Game comparison links in the FAQ (`fastest/ocaml-java.html`, `fastest/haskell.html`) return 404 — the site no longer publishes Java-vs-OCaml/Haskell comparison pages, so fixing these requires a content decision.

## Test plan
- `npm run build` passes; all 9 pages generate.
- All updated URLs verified to return 200.

🤖 Generated with [Claude Code](https://claude.com/claude-code)