### PR TITLE
perf: lazy-load below-the-fold images and improve font loading

### DIFF
--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -26,7 +26,9 @@ import '../styles/global.css';
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>{title}</title>
     <link rel="canonical" href={canonicalURL} />
-    <link href="https://fonts.googleapis.com/css?family=Open+Sans" rel="stylesheet">
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css?family=Open+Sans&display=swap" rel="stylesheet">
     <link href="/favicon.png" rel="icon">
   </head>
   <body>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -590,6 +590,7 @@ import {
             src="/images/standardLibrary.png"
             class="card-img"
             alt="Standard Library"
+            loading="lazy"
           />
         </div>
       </div>
@@ -626,6 +627,7 @@ import {
           src="/images/speedupWithPar.png"
           class="img-fluid"
           alt="Parallel Speedup"
+          loading="lazy"
         />
       </div>
     </div>
@@ -799,7 +801,7 @@ import {
       <!-- TODO add the rest of images (we need to find a good carousel replacement for Astro) -->
       <div class="mt-3 ml-4 mr-4 carousel slide">
         <div class="carousel-inner">
-          <div class="carousel-item active"><img class="d-block w-100" src="/images/vscode1.png">
+          <div class="carousel-item active"><img class="d-block w-100" src="/images/vscode1.png" loading="lazy">
             <div class="carousel-caption d-none d-md-block mb-4">
               <h3>Semantic Highlighting</h3>
             </div>
@@ -924,7 +926,7 @@ import {
 
     <div class="row mb-4">
       <div class="col-md-6">
-        <img src="/logo/java.png" class="img-fluid p-4" alt="Java Logo" />
+        <img src="/logo/java.png" class="img-fluid p-4" alt="Java Logo" loading="lazy" />
       </div>
       <div class="col-md-6">
         <h2>Flix runs on Java</h2>
@@ -1001,6 +1003,7 @@ import {
               src="/logo/dff.png"
               class="card-img"
               alt="Independent Research Fund Denmark"
+              loading="lazy"
             />
           </div>
         </div>
@@ -1010,6 +1013,7 @@ import {
               src="/logo/direc.png"
               class="card-img"
               alt="Digital Research Centre Denmark"
+              loading="lazy"
             />
           </div>
         </div>
@@ -1019,12 +1023,13 @@ import {
               src="/logo/amazon-science.png"
               class="card-img"
               alt="Amazon Research Award"
+              loading="lazy"
             />
           </div>
         </div>
         <div class="col">
           <div class="card border-0 p-3">
-            <img src="/logo/stibo.png" class="card-img" alt="StiboFonden" />
+            <img src="/logo/stibo.png" class="card-img" alt="StiboFonden" loading="lazy" />
           </div>
         </div>
       </div>
@@ -1043,6 +1048,7 @@ import {
               src="/logo/aarhusu.png"
               class="card-img"
               alt="Aarhus University"
+              loading="lazy"
             />
           </div>
         </div>
@@ -1052,6 +1058,7 @@ import {
               src="/logo/uwaterloo.png"
               class="card-img"
               alt="University of Waterloo"
+              loading="lazy"
             />
           </div>
         </div>
@@ -1061,6 +1068,7 @@ import {
               src="/logo/tubingen.png"
               class="card-img"
               alt="University of Tubingen"
+              loading="lazy"
             />
           </div>
         </div>

--- a/src/pages/internships.astro
+++ b/src/pages/internships.astro
@@ -55,7 +55,7 @@ import Layout from '../layouts/Layout.astro';
       </div>
 
       <div class="col-md-6">
-        <img src="/images/katrinebjerg.jpg" class="img-fluid" alt="Dept. of Computer Science" />
+        <img src="/images/katrinebjerg.jpg" class="img-fluid" alt="Dept. of Computer Science" loading="lazy" />
       </div>
     </div>
   </div>

--- a/src/pages/vscode.astro
+++ b/src/pages/vscode.astro
@@ -58,13 +58,13 @@ const features = [
       </div>
     </div>
 
-    {features.map(f => (
+    {features.map((f, i) => (
       <div class="row mb-5">
         <div class="col-md-6">
           <h4>{f.title}</h4>
           <p set:html={f.desc}></p>
           <div class="card">
-            <img class="card-img-top" src={f.img} alt={f.alt} />
+            <img class="card-img-top" src={f.img} alt={f.alt} loading={i === 0 ? "eager" : "lazy"} />
           </div>
         </div>
       </div>


### PR DESCRIPTION
## Summary

Items 9 and 10 from the site audit:

**Font loading** (`Layout.astro`)
- Add `<link rel=preconnect>` for `fonts.googleapis.com` and `fonts.gstatic.com` so the font connection is established early
- Add `&display=swap` to the Google Fonts URL so text renders immediately in a fallback font instead of blocking on Open Sans

**Lazy-loading images**
- `loading=lazy` on all below-the-fold images: all 11 images on the index page, 6 of 7 feature screenshots on the vscode page, and the department photo on the internships page
- Deliberately kept eager: the fork-me ribbon (above the fold everywhere), `install.png` on get-started (main content / likely LCP element), and the first vscode feature screenshot (near the fold)

## Testing

- `npm run build` completes cleanly; all 9 pages generated
- Verified built HTML: preconnect + `display=swap` links present; `loading=lazy` counts per page match expectations (index: 11, vscode: 6, internships: 1)

🤖 Generated with [Claude Code](https://claude.com/claude-code)