### PR TITLE
feat: add 404 page

### DIFF
--- a/src/pages/404.astro
+++ b/src/pages/404.astro
@@ -1,0 +1,21 @@
+---
+import Layout from '../layouts/Layout.astro';
+---
+<Layout title="Flix | Page Not Found">
+  <div class="container">
+    <div class="row mb-3">
+      <div class="col">
+        <h1>Page Not Found</h1>
+        <p>Sorry, the page you are looking for does not exist.</p>
+        <p>
+          Head back to the <a href="/">front page</a> or explore the
+          <a href="/documentation/">documentation</a>.
+        </p>
+        <p>
+          If you followed a broken link on flix.dev, feel free to report it on
+          <a href="https://github.com/flix/flix.dev/issues">GitHub</a>.
+        </p>
+      </div>
+    </div>
+  </div>
+</Layout>


### PR DESCRIPTION
## Summary

Item 13 from the site audit: adds `src/pages/404.astro`, a simple "Page Not Found" page using the shared layout and the site's existing Bootstrap conventions. Links back to the front page and documentation, plus a pointer to the issue tracker for reporting broken links.

## Notes

- Astro emits `dist/404.html` at the dist root — GitHub Pages, Netlify, Cloudflare Pages, and most static hosts serve it automatically for unmatched routes; no host configuration needed
- `@astrojs/sitemap` excludes the 404 route from the sitemap (verified in the build output)

## Testing

- `npm run build` completes cleanly; `dist/404.html` generated with correct title and content
- Verified `dist/sitemap-0.xml` does not reference the 404 page

🤖 Generated with [Claude Code](https://claude.com/claude-code)
