### PR TITLE
perf: self-host Open Sans instead of loading from Google Fonts

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.2.0",
       "dependencies": {
         "@astrojs/sitemap": "^3.7.3",
+        "@fontsource/open-sans": "^5.3.0",
         "@iconify-json/fa-brands": "^1.2.2",
         "@iconify-json/fa-solid": "^1.2.2",
         "@iconify-json/mdi": "^1.2.3",
@@ -1145,6 +1146,15 @@
       ],
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/@fontsource/open-sans": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/@fontsource/open-sans/-/open-sans-5.3.0.tgz",
+      "integrity": "sha512-V1bdMlGNyZrJwzrdusshMOw2YR0aqYDL7kOo9dkxUEKl8dFv66A9HLckOOXl572sG/7ohhDQrCrTFGSn9LZcSw==",
+      "license": "OFL-1.1",
+      "funding": {
+        "url": "https://github.com/sponsors/ayuhito"
       }
     },
     "node_modules/@iconify-json/fa-brands": {

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
   },
   "dependencies": {
     "@astrojs/sitemap": "^3.7.3",
+    "@fontsource/open-sans": "^5.3.0",
     "@iconify-json/fa-brands": "^1.2.2",
     "@iconify-json/fa-solid": "^1.2.2",
     "@iconify-json/mdi": "^1.2.3",

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -1,5 +1,6 @@
 ---
 import 'bootstrap/dist/css/bootstrap.min.css';
+import '@fontsource/open-sans/400.css';
 
 const { title } = Astro.props;
 const currentPath = Astro.url.pathname;
@@ -26,9 +27,6 @@ import '../styles/global.css';
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>{title}</title>
     <link rel="canonical" href={canonicalURL} />
-    <link rel="preconnect" href="https://fonts.googleapis.com">
-    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link href="https://fonts.googleapis.com/css?family=Open+Sans&display=swap" rel="stylesheet">
     <link href="/favicon.png" rel="icon">
   </head>
   <body>


### PR DESCRIPTION
## Summary
- Replace the Google Fonts `<link>` tags (two preconnects + stylesheet) in `Layout.astro` with the `@fontsource/open-sans` npm package, bundled by Astro the same way Bootstrap already is
- Weight 400 only, matching what the Google Fonts URL served, so rendering is unchanged

## Details
- Fontsource ships the same unicode-range subsets Google serves, so browsers still download only the subset they need (latin is ~16 KB woff2), now from flix.dev itself
- `font-display: swap` is preserved
- Removes the last third-party request from the site: no DNS/TLS round-trip to two Google domains, and visitors' IPs are no longer sent to Google (GDPR)
- Verified: `dist/` contains the hashed `.woff2` files and zero references to `fonts.googleapis.com` / `fonts.gstatic.com` after `npm run build`

🤖 Generated with [Claude Code](https://claude.com/claude-code)