### PR TITLE
fix: add Props types to Carousel to satisfy astro check

### DIFF
--- a/src/components/Carousel.astro
+++ b/src/components/Carousel.astro
@@ -1,4 +1,9 @@
 ---
+interface Props {
+  items: { src: string; header: string }[];
+  class?: string;
+}
+
 const { items, class: className } = Astro.props;
 ---
 


### PR DESCRIPTION
## Summary

Fixes the CI failure on master. PR #173 (restore carousel) and PR #174 (add `astro check` to CI) were each green on their own branches, but conflict semantically: the carousel's untyped `items` prop produces four implicit-`any` errors (`ts(7006)`) under `astro check`, which broke CI once both merged.

This adds a `Props` interface to `Carousel.astro` typing `items` as `{ src: string; header: string }[]` (matching the `vscodeSlides` data in `index.astro`) and `class` as an optional string.

## Testing

- `npm run check` — 0 errors, 0 warnings, 0 hints (was 4 errors)
- `npm run build` — completes cleanly, all 10 pages generated

🤖 Generated with [Claude Code](https://claude.com/claude-code)
