### PR TITLE
style: unify keyword color to magenta and tighten code line-height

### DIFF
--- a/src/components/InlineEditor.astro
+++ b/src/components/InlineEditor.astro
@@ -11,7 +11,7 @@ const theme = {
   ...lightPlus,
   name: "light-plus-flix",
   tokenColors: [
-    ...lightPlus.tokenColors,
+    ...(lightPlus.tokenColors ?? []),
     { scope: ["keyword", "storage"], settings: { foreground: "#AF00DB" } },
   ],
 };

--- a/src/components/InlineEditor.astro
+++ b/src/components/InlineEditor.astro
@@ -1,12 +1,24 @@
 ---
 import { Code } from "astro:components";
+import lightPlus from "@shikijs/themes/light-plus";
 const { code } = Astro.props;
 
 import flixGrammar from "../grammars/flix.tmLanguage.json";
+
+// Light+ colors `keyword`/`storage` blue but `keyword.control` magenta;
+// unify them so all Flix keywords share the magenta.
+const theme = {
+  ...lightPlus,
+  name: "light-plus-flix",
+  tokenColors: [
+    ...lightPlus.tokenColors,
+    { scope: ["keyword", "storage"], settings: { foreground: "#AF00DB" } },
+  ],
+};
 ---
 
 <div class="inline-editor-frame">
   <div class="inline-editor-code">
-    <Code code={code} theme="light-plus" lang={flixGrammar} />
+    <Code code={code} theme={theme} lang={flixGrammar} />
   </div>
 </div>

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -58,7 +58,7 @@ p:last-child {
     font-family:
         Monaco, Menlo, "Ubuntu Mono", Consolas, "Source Code Pro",
         source-code-pro, monospace;
-    line-height: 16px;
+    line-height: 14px;
 }
 
 .inline-editor-code pre {


### PR DESCRIPTION
## Summary
- Render all Flix keywords in the front-page code samples in the same magenta (`#AF00DB`) that Light+ already uses for control keywords like `foreach` and `match`. Done by passing a modified Light+ theme to Astro''s `<Code>` component with one extra token rule for the base `keyword`/`storage` scopes.
- Tighten the code samples'' line-height from 16px to 14px (12px font).

Non-keyword tokens such as `Ok`/`Err`/`Nil` (`constant.language.*`) and `${...}` interpolation delimiters keep their Light+ blue, matching VS Code behavior.

## Test plan
- `npm run build` passes; verified in `dist/index.html` that `def`, `let`, `pub`, etc. now render with `color:#AF00DB`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)