### PR TITLE
chore: point performance links to perf.flix.dev

### DIFF
--- a/src/pages/documentation.astro
+++ b/src/pages/documentation.astro
@@ -33,7 +33,7 @@ const smallLinks = [
   },
   {
     text: "Perf",
-    link: "https://arewefast.flix.dev/",
+    link: "https://perf.flix.dev/",
     icon: "octicon:graph-24",
   },
 ];

--- a/src/pages/faq.astro
+++ b/src/pages/faq.astro
@@ -376,7 +376,7 @@ import Question from "../components/FAQ/Question.astro";
       <div>
         The <a href="https://doc.flix.dev/research-literature.html">research</a
         >, the <a href="https://github.com/flix/flix">code</a>, and the <a
-          href="https://arewefast.flix.dev/">performance</a
+          href="https://perf.flix.dev/">performance</a
         >.
       </div>
     </QA>


### PR DESCRIPTION
Updates the two links to the performance dashboard from `arewefast.flix.dev` to `perf.flix.dev`.

- `src/pages/documentation.astro` — the "Perf" card in the resource list
- `src/pages/faq.astro` — the inline "performance" link in the "sounds like vaporware" answer

`astro check` passes (0 errors, 0 warnings).

🤖 Generated with [Claude Code](https://claude.com/claude-code)