### PR TITLE
feat: add meta descriptions to all pages

### DIFF
--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -2,7 +2,12 @@
 import 'bootstrap/dist/css/bootstrap.min.css';
 import '@fontsource/open-sans/400.css';
 
-const { title } = Astro.props;
+interface Props {
+  title: string;
+  description: string;
+}
+
+const { title, description } = Astro.props;
 const currentPath = Astro.url.pathname;
 const canonicalURL = new URL(currentPath, Astro.site);
 
@@ -26,6 +31,7 @@ import '../styles/global.css';
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>{title}</title>
+    <meta name="description" content={description} />
     <link rel="canonical" href={canonicalURL} />
     <link href="/favicon.png" rel="icon">
   </head>

--- a/src/pages/404.astro
+++ b/src/pages/404.astro
@@ -1,7 +1,10 @@
 ---
 import Layout from '../layouts/Layout.astro';
 ---
-<Layout title="Flix | Page Not Found">
+<Layout
+  title="Flix | Page Not Found"
+  description="The page you are looking for does not exist. Head back to the front page or explore the Flix documentation."
+>
   <div class="container">
     <div class="row mb-3">
       <div class="col">

--- a/src/pages/blog.astro
+++ b/src/pages/blog.astro
@@ -1,7 +1,10 @@
 ---
 import Layout from '../layouts/Layout.astro';
 ---
-<Layout title="Flix | Blog">
+<Layout
+  title="Flix | Blog"
+  description="The Flix blog has moved to blog.flix.dev, where we write about programming languages, language design, compilers, and type and effect systems."
+>
   <div class="container">
     <div class="row mb-3">
       <div class="col">

--- a/src/pages/contribute.astro
+++ b/src/pages/contribute.astro
@@ -2,7 +2,10 @@
 import Layout from "../layouts/Layout.astro";
 ---
 
-<Layout title="Flix | Contribute">
+<Layout
+  title="Flix | Contribute"
+  description="Flix is open source under Apache 2.0. Contribute on GitHub, join the discussion on Zulip, or work with us through open source mentoring and student projects."
+>
   <div class="container">
     <div class="row mb-3">
       <div class="col">

--- a/src/pages/documentation.astro
+++ b/src/pages/documentation.astro
@@ -39,7 +39,10 @@ const smallLinks = [
 ];
 ---
 
-<Layout title="Flix | Documentation">
+<Layout
+  title="Flix | Documentation"
+  description="Flix documentation: the Programming Flix book, the standard library API reference, research literature, and community resources on Zulip and GitHub."
+>
   <div class="container">
     <div class="row mb-3">
       <div class="col">

--- a/src/pages/faq.astro
+++ b/src/pages/faq.astro
@@ -4,7 +4,10 @@ import QA from "../components/FAQ/QA.astro";
 import Question from "../components/FAQ/Question.astro";
 ---
 
-<Layout title="Flix | FAQ">
+<Layout
+  title="Flix | FAQ"
+  description="Common questions about Flix: how to learn it, editor and LSP support."
+>
   <div class="container">
     <h1>Frequently Asked Questions</h1>
     <p class="mb-3">

--- a/src/pages/get-started.astro
+++ b/src/pages/get-started.astro
@@ -2,7 +2,10 @@
 import Layout from "../layouts/Layout.astro";
 ---
 
-<Layout title="Flix | Getting Started">
+<Layout
+  title="Flix | Getting Started"
+  description="Start writing Flix: install the Visual Studio Code extension, try the online playground at play.flix.dev, or install the compiler locally."
+>
   <div class="container">
     <h1>Get Started</h1>
 

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -32,7 +32,10 @@ const vscodeSlides = [
 ];
 ---
 
-<Layout title="The Flix Programming Language">
+<Layout
+  title="The Flix Programming Language"
+  description="Flix is an effect-oriented programming language combining functional, imperative, and logic programming, with algebraic effects, traits, and first-class Datalog."
+>
   <div class="container">
     <div class="row mb-3">
       <div class="col-md-6">

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -34,7 +34,7 @@ const vscodeSlides = [
 
 <Layout
   title="The Flix Programming Language"
-  description="Flix is an effect-oriented language pairing algebraic effects and handlers with a complete toolchain: compiler, LSP, REPL, and build tool in one binary."
+  description="Flix is a principled effect-oriented functional, imperative, and logic programming language developed at Aarhus University and by a community of open source contributors."
 >
   <div class="container">
     <div class="row mb-3">

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -34,7 +34,7 @@ const vscodeSlides = [
 
 <Layout
   title="The Flix Programming Language"
-  description="Flix is an effect-oriented programming language combining functional, imperative, and logic programming, with algebraic effects, traits, and first-class Datalog."
+  description="Flix is an effect-oriented language pairing algebraic effects and handlers with a complete toolchain: compiler, LSP, REPL, and build tool in one binary."
 >
   <div class="container">
     <div class="row mb-3">

--- a/src/pages/internships.astro
+++ b/src/pages/internships.astro
@@ -2,7 +2,10 @@
 import Layout from '../layouts/Layout.astro';
 ---
 
-<Layout title="Flix | Internships">
+<Layout
+  title="Flix | Internships"
+  description="Research internships at Aarhus University for students interested in compilers, programming languages, and functional programming."
+>
   <div class="container">
     <div class="row mb-3">
       <div class="col-md-12">

--- a/src/pages/principles.astro
+++ b/src/pages/principles.astro
@@ -2,7 +2,10 @@
 import Layout from "../layouts/Layout.astro"
 import Principle from "../components/Principle.astro"
 ---
-<Layout title="Flix | Principles">
+<Layout
+  title="Flix | Principles"
+  description="The design principles behind Flix and the rationale for its language, tooling, and library decisions."
+>
   <div class="container">
     <h1>Design Principles</h1>
 

--- a/src/pages/vscode.astro
+++ b/src/pages/vscode.astro
@@ -49,7 +49,10 @@ const features = [
 ];
 ---
 
-<Layout title="Flix | Visual Studio Code Features">
+<Layout
+  title="Flix | Visual Studio Code Features"
+  description="See the Flix Visual Studio Code extension in action: inline diagnostics, auto-completion, snippets, hovers, renaming, quick fixes, and code lenses."
+>
   <div class="container">
     <div class="row mb-3">
       <div class="col">


### PR DESCRIPTION
None of the ten pages carried a `<meta name="description">`. Search engines were synthesising snippets from page content — on the homepage that means starting from `<h1>Flix &mdash;</h1>` — and chat clients had no text to unfurl.

## Changes

`Layout.astro` gains a typed `Props` interface and renders the tag:

```astro
interface Props {
  title: string;
  description: string;
}
```

`description` is **required rather than optional**, so a page added later without one fails `astro check` — already run by CI on every push and PR. This also types `title`, which was previously implicit `any`.

Each of the ten pages then passes a description written from its actual content, 69–157 characters, front-loaded so the distinctive part survives truncation.

## Scope

Description tag only. `og:*` and `twitter:*` are still absent — those need a 1200×630 card image designed before the markup does anything, so they are left for a follow-up. No JSON-LD.

## Verification

- `npm run check` — 0 errors, 0 warnings, 0 hints across 20 files
- `npm run build` — clean, 10 pages
- Confirmed in the built HTML that all ten pages carry a unique description

🤖 Generated with [Claude Code](https://claude.com/claude-code)