### PR TITLE
chore: tighten types, enable prefetch, and stop indexing stub pages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 
 # misc
 .DS_Store
+.idea/
 
 # generated
 .astro/

--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -5,5 +5,16 @@ import sitemap from '@astrojs/sitemap';
 
 export default defineConfig({
   site: 'https://flix.dev',
-  integrations: [icon(), sitemap()]
+  // Prefetch every internal link on hover; the nav links to nine pages.
+  prefetch: {
+    prefetchAll: true
+  },
+  integrations: [
+    icon(),
+    // /blog is a stub pointing at blog.flix.dev and is marked noindex, so it
+    // does not belong in the sitemap either.
+    sitemap({
+      filter: (page) => !page.endsWith('/blog/')
+    })
+  ]
 });

--- a/src/components/InlineEditor.astro
+++ b/src/components/InlineEditor.astro
@@ -1,6 +1,10 @@
 ---
 import { Code } from "astro:components";
 import lightPlus from "@shikijs/themes/light-plus";
+interface Props {
+  code: string;
+}
+
 const { code } = Astro.props;
 
 import flixGrammar from "../grammars/flix.tmLanguage.json";

--- a/src/components/Principle.astro
+++ b/src/components/Principle.astro
@@ -1,4 +1,8 @@
 ---
+interface Props {
+  name: string;
+}
+
 const { name } = Astro.props;
 ---
 

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -5,9 +5,12 @@ import '@fontsource/open-sans/400.css';
 interface Props {
   title: string;
   description: string;
+  /** Keep the page out of the index. Also drops the canonical link, which a
+      non-indexable page should not claim. */
+  noindex?: boolean;
 }
 
-const { title, description } = Astro.props;
+const { title, description, noindex = false } = Astro.props;
 const currentPath = Astro.url.pathname;
 const canonicalURL = new URL(currentPath, Astro.site);
 
@@ -32,7 +35,13 @@ import '../styles/global.css';
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>{title}</title>
     <meta name="description" content={description} />
-    <link rel="canonical" href={canonicalURL} />
+    {
+      noindex ? (
+        <meta name="robots" content="noindex, follow" />
+      ) : (
+        <link rel="canonical" href={canonicalURL} />
+      )
+    }
     <link href="/favicon.png" rel="icon">
   </head>
   <body>

--- a/src/pages/404.astro
+++ b/src/pages/404.astro
@@ -4,6 +4,7 @@ import Layout from '../layouts/Layout.astro';
 <Layout
   title="Flix | Page Not Found"
   description="The page you are looking for does not exist. Head back to the front page or explore the Flix documentation."
+  noindex
 >
   <div class="container">
     <div class="row mb-3">

--- a/src/pages/blog.astro
+++ b/src/pages/blog.astro
@@ -4,6 +4,7 @@ import Layout from '../layouts/Layout.astro';
 <Layout
   title="Flix | Blog"
   description="The Flix blog has moved to blog.flix.dev, where we write about programming languages, language design, compilers, and type and effect systems."
+  noindex
 >
   <div class="container">
     <div class="row mb-3">

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "astro/tsconfigs/base",
+  "extends": "astro/tsconfigs/strict",
   "include": [".astro/types.d.ts", "**/*"],
   "exclude": ["dist"]
 }


### PR DESCRIPTION
Six small cleanups from the Astro best-practices review. All mechanical, all verified against a build.

## 1. `tsconfig` → `astro/tsconfigs/strict`
The baseline Astro recommends; the project was on `base`, which leaves strict mode off. Costs nothing here — `astro check` stays at **0 errors, 0 warnings, 0 hints**.

## 2. `interface Props` on `InlineEditor` and `Principle`
The last two components with implicitly-`any` props. `Carousel` and `Layout` were already typed.

## 3. Enable prefetch
```js
prefetch: { prefetchAll: true }
```
`prefetch: true` on its own leaves `prefetchAll` at `false`, so only links carrying `data-astro-prefetch` would be prefetched — the nine-link nav would get nothing. The object form covers every internal link, on hover.

Cost: a **2.5 KB** module script now loads on all ten pages, which previously shipped no external JS. Verified the homepage carousel's inline script is unaffected.

## 4. `.idea/` into `.gitignore`
It has been showing up untracked in every `git status` and in two `gh pr create` warnings.

## 5. + 6. `noindex` for the 404 and `/blog`

`Layout` gains a `noindex` prop that emits `<meta name="robots" content="noindex, follow">` **and drops the canonical link** — a page that shouldn't be indexed has no business claiming a canonical URL.

- **404** previously self-canonicalised to `https://flix.dev/404/`, telling crawlers that every missing URL is canonically the 404 page.
- **`/blog`** is a 1.7 KB stub whose only content is a link to blog.flix.dev. It's now `noindex` *and* filtered out of the sitemap — no point asking Google to crawl a page we then tell it to drop.

I chose `noindex` over a redirect because the navbar links to `/blog` and the page explains where the blog went; a redirect would bounce visitors straight off the site. Easy to switch if you'd rather.

## Verification

```
astro check          0 errors, 0 warnings, 0 hints (strict)
build                clean, 10 pages

404.html             <meta name="robots" content="noindex, follow">   (no canonical)
blog/index.html      <meta name="robots" content="noindex, follow">   (no canonical)
index.html           <link rel="canonical" href="https://flix.dev/">  (unchanged)

sitemap              8 URLs, /blog absent
prefetch             prefetchAll baked in, script on all 10 pages
.idea/               now ignored
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)