### PR TITLE
fix: correct invalid grid nesting, heading nesting, and navbar collapse

### DIFF
--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -53,19 +53,43 @@ import '../styles/global.css';
     <div class="container page">
       <nav class="navbar navbar-dark bg-info navbar-expand-md menu shadow-sm mb-4">
         <div class="container-fluid">
-          <ul class="navbar-nav mr-lg-auto">
-            {navLinks.map(({ href, label }) => (
-              <li class="nav-item pl-1 pr-1">
-                <a class={`nav-link${currentPath === href ? " active font-weight-bold" : ""}`} href={href}>
-                  {label}
-                </a>
-              </li>
-            ))}
-          </ul>
+          <button
+            class="navbar-toggler"
+            type="button"
+            aria-controls="main-nav"
+            aria-expanded="false"
+            aria-label="Toggle navigation"
+          >
+            <span class="navbar-toggler-icon"></span>
+          </button>
+          <div class="collapse navbar-collapse" id="main-nav">
+            <ul class="navbar-nav mr-lg-auto">
+              {navLinks.map(({ href, label }) => (
+                <li class="nav-item pl-1 pr-1">
+                  <a class={`nav-link${currentPath === href ? " active font-weight-bold" : ""}`} href={href}>
+                    {label}
+                  </a>
+                </li>
+              ))}
+            </ul>
+          </div>
         </div>
       </nav>
 
       <slot />
     </div>
+
+    <script>
+      // Bootstrap's collapse JS needs jQuery, which the site does not load. Its
+      // CSS hides .collapse:not(.show) below the md breakpoint, so this script
+      // only toggles that class. Above md, .navbar-collapse is display:flex
+      // !important, so a stale .show is harmless when resizing back up.
+      const toggler = document.querySelector<HTMLButtonElement>(".navbar-toggler");
+      const target = document.getElementById("main-nav");
+      toggler?.addEventListener("click", () => {
+        const open = target?.classList.toggle("show") ?? false;
+        toggler.setAttribute("aria-expanded", String(open));
+      });
+    </script>
   </body>
 </html>

--- a/src/pages/blog.astro
+++ b/src/pages/blog.astro
@@ -12,7 +12,7 @@ import Layout from '../layouts/Layout.astro';
         <h1>Blog</h1>
         <p>The Flix Blog is now available at:</p>
         <div class="mt-3">
-          <a href="https://blog.flix.dev/"><h2>https://blog.flix.dev/</h2></a>
+          <h2><a href="https://blog.flix.dev/">https://blog.flix.dev/</a></h2>
         </div>
       </div>
     </div>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -994,85 +994,87 @@ const vscodeSlides = [
 
     <hr class="mb-4" />
 
-    <div class="row mb-4">
+    <div class="row">
       <div class="col-md-12">
         <h2>Sponsors and Funding</h2>
       </div>
-      <div class="row">
-        <div class="col">
-          <div class="card border-0 p-3">
-            <img
-              src="/logo/dff.png"
-              class="card-img"
-              alt="Independent Research Fund Denmark"
-              loading="lazy"
-            />
-          </div>
+    </div>
+
+    <div class="row mb-4">
+      <div class="col">
+        <div class="card border-0 p-3">
+          <img
+            src="/logo/dff.png"
+            class="card-img"
+            alt="Independent Research Fund Denmark"
+            loading="lazy"
+          />
         </div>
-        <div class="col">
-          <div class="card border-0 p-3">
-            <img
-              src="/logo/direc.png"
-              class="card-img"
-              alt="Digital Research Centre Denmark"
-              loading="lazy"
-            />
-          </div>
+      </div>
+      <div class="col">
+        <div class="card border-0 p-3">
+          <img
+            src="/logo/direc.png"
+            class="card-img"
+            alt="Digital Research Centre Denmark"
+            loading="lazy"
+          />
         </div>
-        <div class="col">
-          <div class="card border-0 p-3">
-            <img
-              src="/logo/amazon-science.png"
-              class="card-img"
-              alt="Amazon Research Award"
-              loading="lazy"
-            />
-          </div>
+      </div>
+      <div class="col">
+        <div class="card border-0 p-3">
+          <img
+            src="/logo/amazon-science.png"
+            class="card-img"
+            alt="Amazon Research Award"
+            loading="lazy"
+          />
         </div>
-        <div class="col">
-          <div class="card border-0 p-3">
-            <img src="/logo/stibo.png" class="card-img" alt="StiboFonden" loading="lazy" />
-          </div>
+      </div>
+      <div class="col">
+        <div class="card border-0 p-3">
+          <img src="/logo/stibo.png" class="card-img" alt="StiboFonden" loading="lazy" />
         </div>
       </div>
     </div>
 
     <hr class="mb-4" />
 
-    <div class="row mb-4">
+    <div class="row">
       <div class="col-md-12">
         <h2>Collaborators</h2>
       </div>
-      <div class="row">
-        <div class="col-md-3">
-          <div class="card border-0 p-3">
-            <img
-              src="/logo/aarhusu.png"
-              class="card-img"
-              alt="Aarhus University"
-              loading="lazy"
-            />
-          </div>
+    </div>
+
+    <div class="row mb-4">
+      <div class="col-md-3">
+        <div class="card border-0 p-3">
+          <img
+            src="/logo/aarhusu.png"
+            class="card-img"
+            alt="Aarhus University"
+            loading="lazy"
+          />
         </div>
-        <div class="col-md-4">
-          <div class="card border-0 p-3">
-            <img
-              src="/logo/uwaterloo.png"
-              class="card-img"
-              alt="University of Waterloo"
-              loading="lazy"
-            />
-          </div>
+      </div>
+      <div class="col-md-4">
+        <div class="card border-0 p-3">
+          <img
+            src="/logo/uwaterloo.png"
+            class="card-img"
+            alt="University of Waterloo"
+            loading="lazy"
+          />
         </div>
-        <div class="col-md-3">
-          <div class="card border-0 p-3">
-            <img
-              src="/logo/tubingen.png"
-              class="card-img"
-              alt="University of Tubingen"
-              loading="lazy"
-            />
-          </div>
+      </div>
+      <div class="col-md-3">
+        <div class="card border-0 p-3">
+          <img
+            src="/logo/tubingen.png"
+            class="card-img"
+            alt="University of Tubingen"
+            loading="lazy"
+          />
         </div>
       </div>
     </div>


### PR DESCRIPTION
Three markup issues found while auditing the site.

### `.row` nested directly inside `.row` — `src/pages/index.astro`

The Sponsors and Collaborators sections put the heading and the logo grid as siblings inside a single `.row`, so the inner `.row`'s -15px negative margins applied with no `.col` padding to cancel them. Split each into two sibling rows, moving `mb-4` to the logo row so the spacing before the following `<hr>` is unchanged.

Verified in the build output: `<div>` open/close counts balance (216/216) and there are no remaining row-in-row occurrences.

### Heading wrapped in an anchor — `src/pages/blog.astro`

`<a><h2>…</h2></a>` → `<h2><a href="…">…</a></h2>`. Renders identically; the `<a>` still supplies the link color the `<h2>` was inheriting.

### Navbar with no collapse or toggler — `src/layouts/Layout.astro`

The `<ul>` was not inside a `.collapse.navbar-collapse` and there was no toggler, so `navbar-expand-md` just stacked nine links vertically on mobile with no hamburger.

This one needed more than markup. Bootstrap's `.collapse:not(.show){display:none}` would have hidden the nav outright below 768px, and Bootstrap 4's collapse JS requires jQuery, which this site doesn't load. So the toggler ships a small script that toggles `.show` and keeps `aria-expanded` in sync — the same no-jQuery approach the `Carousel` component already uses. The button gets `aria-label` and `aria-controls` since it's a new control.

Checked against the compiled Bootstrap CSS that both `.navbar-expand-md .navbar-collapse{display:flex!important}` and `.navbar-expand-md .navbar-toggler{display:none}` sit inside `@media (min-width:768px)`, so the desktop nav is untouched and a leftover `.show` is harmless when resizing back up. `.navbar-dark .navbar-toggler-icon` supplies a white hamburger, so the button is visible on the `bg-info` bar.

## Behavior change

Below 768px the nine nav links previously stacked vertically and were always visible; they are now behind the hamburger. That's the point of the fix, but it is the only user-visible change in this PR — worth a look on a phone before merging.

## Testing

- `astro check` — 0 errors, 0 warnings, 0 hints
- `astro build` — 10 pages built
- Structural verification of the emitted HTML as described above

No accessibility, SEO, performance, or security items from the wider audit are touched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)