### PR TITLE
feat: cross-fade page navigations with view transitions

### DIFF
--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -1,3 +1,16 @@
+/* Cross-fade same-origin navigations instead of flashing white. Browsers
+   without cross-document view transitions (e.g. Firefox) ignore this and
+   keep plain full-page loads. */
+@view-transition {
+    navigation: auto;
+}
+
+@media (prefers-reduced-motion) {
+    @view-transition {
+        navigation: none;
+    }
+}
+
 body {
     font-family: 'Open Sans', sans-serif;
     overflow-y: scroll;
@@ -30,6 +43,9 @@ p:last-child {
 .menu {
     margin-left: -15px;
     margin-right: -15px;
+    /* The navbar is identical on every page; naming it lifts it out of the
+       root cross-fade so it holds still during transitions. */
+    view-transition-name: navbar;
 }
 
 .page {


### PR DESCRIPTION
## Summary
- Opt same-origin navigations into browser-native cross-document view transitions (`@view-transition { navigation: auto; }`), so page loads cross-fade instead of flashing white
- Give the navbar its own `view-transition-name` so it holds perfectly still while only the page content fades
- Disable the transition under `prefers-reduced-motion`

CSS-only change: these remain real full-page navigations, so the inline navbar and carousel scripts are unaffected. Chrome/Edge 126+ and Safari 18.2+ get the cross-fade; browsers without support (e.g. Firefox) ignore the at-rule and keep todays behavior. Combined with the already-enabled `prefetchAll`, navigation should now look near-seamless.

## Test plan
- `npm run build` passes; verified the `@view-transition` blocks and `view-transition-name` survive CSS bundling into `dist/_astro/Layout.*.css`
- Manual: click between pages in Chrome/Safari and observe a cross-fade with a stationary navbar; verify Firefox still navigates normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)