### PR TITLE
fix: correct typos and grammar errors across pages

### DIFF
--- a/src/pages/contribute.astro
+++ b/src/pages/contribute.astro
@@ -37,7 +37,7 @@ import Layout from "../layouts/Layout.astro";
         </p>
 
         <p>
-          If you are interested working on Flix, please feel free to reach out
+          If you are interested in working on Flix, please feel free to reach out
           to us.
         </p>
       </div>

--- a/src/pages/faq.astro
+++ b/src/pages/faq.astro
@@ -18,7 +18,7 @@ import Question from "../components/FAQ/Question.astro";
       <Question> What is the best way to start learning Flix? </Question>
       <div>
         <p>
-          We recommend to read the <a href="https://doc.flix.dev/"
+          We recommend reading the <a href="https://doc.flix.dev/"
             >Programming Flix</a
           > book.
         </p>
@@ -261,7 +261,7 @@ import Question from "../components/FAQ/Question.astro";
       <div>
         <p>
           The latest compiler version and the website are not always in sync,
-          hence occasionally some examples may stop to work.
+          hence occasionally some examples may stop working.
         </p>
 
         <p>
@@ -279,8 +279,8 @@ import Question from "../components/FAQ/Question.astro";
       <div>
         <p>
           Yes, no programming language developed outside of those four
-          corporations have ever been successful. See also C, C++, Java, Python,
-          PHP, MatLab, Perl, R, Ruby, Scala, ...
+          corporations has ever been successful. See also C, C++, Java, Python,
+          PHP, MATLAB, Perl, R, Ruby, Scala, ...
         </p>
 
         <p>

--- a/src/pages/get-started.astro
+++ b/src/pages/get-started.astro
@@ -12,7 +12,7 @@ import Layout from "../layouts/Layout.astro";
     <div class="row mb-5">
       <div class="col">
         <p>
-          We recommend to use Flix from Visual Studio Code. In addition, Flix
+          We recommend using Flix from Visual Studio Code. In addition, Flix
           has an <a href="https://play.flix.dev/">online playground</a> and can be <a
           href="https://doc.flix.dev/getting-started.html"
             >installed locally</a

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -173,7 +173,7 @@ const vscodeSlides = [
               handlers. In particular, Flix supports multi-shot resumptions.
             </p>
             <p>
-              Effect-oriented programming, with algebraic effects, allow
+              Effect-oriented programming, with algebraic effects, allows
               programmers to write pure functions modulo effects. Effect
               handlers enable program reasoning, modularity, and testability.
             </p>
@@ -202,7 +202,7 @@ const vscodeSlides = [
             <div class="card-title"><h4>Region-based Local Mutation</h4></div>
             <p>
               Flix supports region-based local mutation, which makes it possible
-              to implement <i>pure</i> functions that internally uses mutable state
+              to implement <i>pure</i> functions that internally use mutable state
               and destructive operations, as long as these operations are confined
               to the region.
             </p>
@@ -389,9 +389,9 @@ const vscodeSlides = [
               structures.
             </p>
             <p>
-              The code on the left adds an associated effect <code>Aef</code> to the
-              <code> Coll</code> trait, which makes it possible to add instances for
-              mutable collections.
+              The code on the left adds an associated effect <code>Aef</code> to
+              the <code>Coll</code> trait, which makes it possible to add
+              instances for mutable collections.
             </p>
           </div>
         </div>
@@ -515,9 +515,9 @@ const vscodeSlides = [
             </p>
             <hr />
             <p>
-              Datalog constraints enriched with lattice semantics is one of the
-              more advanced features of Flix and requires some background
-              knowledge of lattice theory and fixpoints.
+              Support for Datalog constraints enriched with lattice semantics is
+              one of the more advanced features of Flix and requires some
+              background knowledge of lattice theory and fixpoints.
             </p>
           </div>
         </div>
@@ -561,7 +561,7 @@ const vscodeSlides = [
         <ul>
           <li>monadic forM expressions</li>
           <li>applicative forA expressions</li>
-          <li>expressions holes</li>
+          <li>expression holes</li>
           <li>compilation to JVM bytecode</li>
           <li>full tail call elimination</li>
           <li>resilient compiler architecture</li>
@@ -578,7 +578,7 @@ const vscodeSlides = [
         <h2>Standard Library with Batteries Included</h2>
         <p>
           Flix comes with a fully-featured Standard Library that offers access
-          to more than <span class="text-success font-weight-bold">4,000+</span
+          to <span class="text-success font-weight-bold">4,000+</span
           > functions.
         </p>
         <p>
@@ -683,7 +683,7 @@ const vscodeSlides = [
         </p>
 
         <p>
-          The performance of Flix compiler is mostly determined by CPU
+          The performance of the Flix compiler is mostly determined by CPU
           performance and memory bandwidth.
         </p>
       </div>
@@ -884,9 +884,9 @@ const vscodeSlides = [
           > in Denmark in collaboration with researchers from the <a
             href="https://uwaterloo.ca/">University of Waterloo</a
           > in Canada, the <a href="https://uni-tuebingen.de/en/"
-            >University of Tubingen</a
+            >University of Tübingen</a
           > in Germany, and <a href="https://di.ku.dk/english/"
-            >Copenhagen University</a
+            >University of Copenhagen</a
           > in Denmark.
         </p>
         <p>
@@ -941,18 +941,18 @@ const vscodeSlides = [
             The JVM has multiple battle-tested, open-source and commercial
             implementations, including OpenJDK, J9, Azul, Graal, and more.
           </li>
-          <li>JVMs exists for all platforms: Mac, Linux, and Windows.</li>
+          <li>JVMs exist for all platforms: Mac, Linux, and Windows.</li>
           <li>
             Modern JVMs feature multiple state-of-the-art garbage collectors.
           </li>
           <li>
             Modern JVMs have excellent support for concurrency and parallelism.
-            In particular, light-weight threads added in Java 21.
+            In particular, light-weight threads were added in Java 21.
           </li>
           <li>Excellent tool support, including debuggers and profilers.</li>
           <li>
             The Java Platform comes with a rich ecosystem of packages which is
-            accessible thru integration with Maven.
+            accessible through integration with Maven.
           </li>
         </ul>
       </div>
@@ -1087,7 +1087,7 @@ const vscodeSlides = [
           <img
             src="/logo/tubingen.png"
             class="card-img"
-            alt="University of Tubingen"
+            alt="University of Tübingen"
             loading="lazy"
           />
         </div>

--- a/src/pages/internships.astro
+++ b/src/pages/internships.astro
@@ -19,7 +19,7 @@ import Layout from '../layouts/Layout.astro';
           Want to work on Flix?
         </p>
 
-        <p>Then join us for a internship at Aarhus University in Denmark!</p>
+        <p>Then join us for an internship at Aarhus University in Denmark!</p>
 
         <hr />
 
@@ -34,7 +34,7 @@ import Layout from '../layouts/Layout.astro';
         </p>
 
         <p>
-          To apply, you should be enrolled in a bachelor's or master's degree programme at an accredited university.
+          To apply, you should be enrolled in a bachelor's or master's degree program at an accredited university.
         </p>
 
         <p>


### PR DESCRIPTION
Fixes typos and grammar errors across the site's pages:

**index.astro**
- "allow" → "allows" (effect-oriented programming)
- "internally uses" → "internally use" (pure functions)
- "expressions holes" → "expression holes"
- "of Flix compiler" → "of the Flix compiler"
- "JVMs exists" → "JVMs exist"
- "thru" → "through"
- Drop redundant "more than" before "4,000+"
- "Tubingen" → "Tübingen" (text and logo alt)
- "Copenhagen University" → "University of Copenhagen"
- Fix sentence fragment: "light-weight threads were added in Java 21"
- Fix stray space in `<code> Coll</code>`
- Rephrase lattice-semantics sentence for subject-verb agreement

**faq.astro**
- "recommend to read" → "recommend reading"
- "stop to work" → "stop working"
- "corporations have ever been" → "corporations has ever been"
- "MatLab" → "MATLAB"

**contribute.astro**
- "interested working" → "interested in working"

**get-started.astro**
- "recommend to use" → "recommend using"

**internships.astro**
- "a internship" → "an internship"
- "programme" → "program" (consistency with other pages)

🤖 Generated with [Claude Code](https://claude.com/claude-code)