### PR TITLE
fix: let the sponsor logos reflow on small screens

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -1102,7 +1102,7 @@ const vscodeSlides = [
     </div>
 
     <div class="row mb-4">
-      <div class="col">
+      <div class="col-md">
         <div class="card border-0 p-3">
           <img
             src="/logo/dff.png"
@@ -1112,7 +1112,7 @@ const vscodeSlides = [
           />
         </div>
       </div>
-      <div class="col">
+      <div class="col-md">
         <div class="card border-0 p-3">
           <img
             src="/logo/dara-academy.png"
@@ -1122,7 +1122,7 @@ const vscodeSlides = [
           />
         </div>
       </div>
-      <div class="col">
+      <div class="col-md">
         <div class="card border-0 p-3">
           <img
             src="/logo/direc.png"
@@ -1132,7 +1132,7 @@ const vscodeSlides = [
           />
         </div>
       </div>
-      <div class="col">
+      <div class="col-md">
         <div class="card border-0 p-3">
           <img
             src="/logo/amazon-science.png"
@@ -1142,7 +1142,7 @@ const vscodeSlides = [
           />
         </div>
       </div>
-      <div class="col">
+      <div class="col-md">
         <div class="card border-0 p-3">
           <img src="/logo/stibo.png" class="card-img" alt="StiboFonden" loading="lazy" />
         </div>


### PR DESCRIPTION
The "Sponsors and Funding" row used bare `col`, whose equal-width rule has no media query:

```css
.col { flex-basis: 0; flex-grow: 1; max-width: 100% }
```

`flex-grow: 1` with `flex-basis: 0` means "split the row evenly" at *every* viewport width, so the five logos stayed five-across down to 320px, each squeezed to about a fifth of the screen.

This switches the five columns to `col-md`, which is the same equal-width rule scoped to the `md` breakpoint:

```css
@media (min-width: 768px) { .col-md { flex-basis: 0; flex-grow: 1; max-width: 100% } }
```

Below 768px the rule drops out and only the shared `width: 100%` base remains, so the logos stack one per row — the same behaviour as the Collaborators row just below, which already uses breakpoint-scoped `col-md-*` classes.

Desktop rendering is unchanged. Verified with `npm run build`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)