### PR TITLE
fix: restore the default underline on links

### DIFF
--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -164,24 +164,6 @@ p:last-child {
     }
 }
 
-/* Bootstrap 5 underlines links by default. The site's links live in running
-   prose and inside whole-card anchors, where a permanent underline reads as a
-   rendering fault, so keep them underlined on hover only. The navbar opts out
-   again: Bootstrap sets text-decoration on .nav-link and .navbar-brand at a
-   specificity a:hover beats, so they need saying a second time. */
-a {
-    text-decoration: none;
-}
-
-a:hover {
-    text-decoration: underline;
-}
-
-.nav-link:hover, .nav-link:focus,
-.navbar-brand:hover, .navbar-brand:focus {
-    text-decoration: none;
-}
-
 /* Bootstrap 5 removed .text-justify. */
 .text-justify {
     text-align: justify;


### PR DESCRIPTION
Bootstrap 5 underlines links. The site turned that off for every link and put the underline back on hover only, which leaves colour as the sole thing separating a link from the text around it. The brand red against black body copy is a hue difference, so it vanishes in greyscale and for a reader who cannot separate the two — and until you hover, nothing says a link is there.

This restores the default. The whole change is a deletion.

### Why nothing had to be added back

- **The navbar keeps its clean look on its own.** Bootstrap sets `text-decoration: none` on `.nav-link` and `.navbar-brand` at class specificity, which the bare `a` selector cannot beat. The two `:hover, :focus` rules that said it a second time existed only to fight the site's own `a:hover`, so they went with it.
- **Icons stay unmarked.** Underlines skip atomic inlines, so the line never touches the icon SVGs on the documentation page — it lands only on the words beside them. The whole-card anchors there needed no opt-out.
- **The "Fork me on GitHub" ribbon is untouched.** Its `<img>` is absolutely positioned, so it takes no decoration from the anchor around it.

### What it looks like

Prose links across the site are underlined; the documentation page underlines the two big card titles in their own colours (red for `doc.flix.dev`, green for `api.flix.dev`) and the six resource labels, while every icon stays clean.

Checked in Firefox on the documentation, FAQ, and home pages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)