### PR TITLE
chore: hand two Bootstrap 4 leftovers back to Bootstrap

### DIFF
--- a/src/pages/contribute.astro
+++ b/src/pages/contribute.astro
@@ -50,7 +50,7 @@ import Layout from "../layouts/Layout.astro";
         <div class="card h-100">
           <div class="card-body">
             <div class="card-title">Open Source Mentoring</div>
-            <p>
+            <p class="card-text">
               We are more than happy to mentor someone who is interested in
               working on compilers and/or programming language design and wants
               to contribute to Flix. We have already had several positive
@@ -64,7 +64,7 @@ import Layout from "../layouts/Layout.astro";
         <div class="card h-100">
           <div class="card-body">
             <div class="card-title">Talent Track Projects</div>
-            <p>
+            <p class="card-text">
               Aarhus University offers a talent track program for capable
               students that are in their second or third year of studies and are
               interested in working on a research project for up to one year as
@@ -78,7 +78,7 @@ import Layout from "../layouts/Layout.astro";
         <div class="card h-100">
           <div class="card-body">
             <div class="card-title">Bachelor and Master Projects</div>
-            <p>
+            <p class="card-text">
               If you are a bachelor or master student at Aarhus University you
               can write your thesis on a topic related to Flix.
             </p>

--- a/src/pages/faq.astro
+++ b/src/pages/faq.astro
@@ -17,13 +17,13 @@ import Question from "../components/FAQ/Question.astro";
     <QA>
       <Question> What is the best way to start learning Flix? </Question>
       <div>
-        <p>
+        <p class="card-text">
           We recommend reading the <a href="https://doc.flix.dev/"
             >Programming Flix</a
           > book.
         </p>
 
-        <p>
+        <p class="card-text">
           If you get stuck or need help feel free to reach out to us on <a
             href="https://flix.zulipchat.com/">Zulip</a
           >.
@@ -78,7 +78,7 @@ import Question from "../components/FAQ/Question.astro";
     <QA>
       <Question> Is Flix a domain specific language (DSL)? </Question>
       <div>
-        <p>No, Flix is a full-blown general-purpose programming language.</p>
+        <p class="card-text">No, Flix is a full-blown general-purpose programming language.</p>
       </div>
     </QA>
 
@@ -87,11 +87,11 @@ import Question from "../components/FAQ/Question.astro";
         Flix looks similar to Scala. How are the two languages related?
       </Question>
       <div>
-        <p>
+        <p class="card-text">
           Flix borrows a lot of syntax from Scala, hence the two languages have
           a similar feel.
         </p>
-        <p>
+        <p class="card-text">
           We think Scala made many good design choices with respect to syntax,
           including:
         </p>
@@ -103,7 +103,7 @@ import Question from "../components/FAQ/Question.astro";
           <li><code>if</code>, <code>match</code>, etc. as expressions.</li>
         </ul>
 
-        <p>However, other than syntax, the two languages are very different:</p>
+        <p class="card-text">However, other than syntax, the two languages are very different:</p>
 
         <ul>
           <li>Scala is object-oriented, Flix is not.</li>
@@ -117,12 +117,12 @@ import Question from "../components/FAQ/Question.astro";
     <QA>
       <Question> What is the runtime performance of Flix programs? </Question>
       <div>
-        <p>
+        <p class="card-text">
           Flix runs on the JVM which means that the performance of Flix programs
           is comparable to that of Java and Scala programs.
         </p>
 
-        <p>
+        <p class="card-text">
           Flix is a whole-program optimizing compiler that uses monomorphization
           and inlining (like Rust and MLton). Hence, sometimes, Flix programs
           run faster than their Java or Scala equivalent.
@@ -153,7 +153,7 @@ import Question from "../components/FAQ/Question.astro";
       <Question> What controversial design choices are made in Flix? </Question>
 
       <div>
-        <p>
+        <p class="card-text">
           The following design choices may be considered controversial by some:
         </p>
 
@@ -233,7 +233,7 @@ import Question from "../components/FAQ/Question.astro";
     <QA>
       <Question>"This site requires JavaScript"</Question>
       <div>
-        <p>
+        <p class="card-text">
           People who criticized the website for using JavaScript: <a
             href="https://news.ycombinator.com/item?id=25516097">[1]</a
           >, <a href="https://news.ycombinator.com/item?id=38419909">[2]</a>, <a
@@ -244,13 +244,13 @@ import Question from "../components/FAQ/Question.astro";
           >.
         </p>
 
-        <p>
+        <p class="card-text">
           People who have offered to help refactor the site to use static html: <a
             href="https://github.com/flix/flix.dev/pull/165"><b>1</b></a
           >.
         </p>
 
-        <p>People who can now complain about the CSS: everyone.</p>
+        <p class="card-text">People who can now complain about the CSS: everyone.</p>
       </div>
     </QA>
 
@@ -259,12 +259,12 @@ import Question from "../components/FAQ/Question.astro";
         It appears that an example on the website does not work?
       </Question>
       <div>
-        <p>
+        <p class="card-text">
           The latest compiler version and the website are not always in sync,
           hence occasionally some examples may stop working.
         </p>
 
-        <p>
+        <p class="card-text">
           Occasionally a mischievous visitor will crash the online editor (or
           rather the virtual machine on which the compiler runs).
         </p>
@@ -277,13 +277,13 @@ import Question from "../components/FAQ/Question.astro";
         unless Apple, Google, Mozilla, or Microsoft is on-board it is pointless.
       </Question>
       <div>
-        <p>
+        <p class="card-text">
           Yes, no programming language developed outside of those four
           corporations has ever been successful. See also C, C++, Java, Python,
           PHP, MATLAB, Perl, R, Ruby, Scala, ...
         </p>
 
-        <p>
+        <p class="card-text">
           That said, if you work for a company and would like to help sponsor
           Flix, please feel free to reach out to us :)
         </p>
@@ -299,7 +299,7 @@ import Question from "../components/FAQ/Question.astro";
         more productive, not because of mass appeal.
       </Question>
       <div>
-        <p>Yes, we do it all for C#.</p>
+        <p class="card-text">Yes, we do it all for C#.</p>
       </div>
     </QA>
 
@@ -310,17 +310,17 @@ import Question from "../components/FAQ/Question.astro";
         of the modern world, all the best with that.
       </Question>
       <div>
-        <p>
+        <p class="card-text">
           Yes, we take inspiration from programming languages that are pushing
           on the boundary of language design.
         </p>
 
-        <p>
+        <p class="card-text">
           What would be the point of taking ideas from C, Perl, PHP, and Visual
           Basic?
         </p>
 
-        <p>
+        <p class="card-text">
           Also, who said that we are taking their most complex ideas? Rather we
           should take their <i>best</i> ideas.
         </p>
@@ -349,15 +349,15 @@ import Question from "../components/FAQ/Question.astro";
     <QA>
       <Question> Do we really need any more programming languages? </Question>
       <div>
-        <p>
+        <p class="card-text">
           <i>Do we really need safer airplanes?</i>
           <i>Do we really need electric cars?</i>
           <i>Do we really need more ergonomic chairs?</i>
         </p>
 
-        <p>I mean, after all, we already have airplanes, cars, and chairs!</p>
+        <p class="card-text">I mean, after all, we already have airplanes, cars, and chairs!</p>
 
-        <p>
+        <p class="card-text">
           We build new programming languages and we conduct research on
           programming language design because we want to offer developers <i
             >better tools to write programs</i
@@ -365,7 +365,7 @@ import Question from "../components/FAQ/Question.astro";
           write correct programs.
         </p>
 
-        <p>
+        <p class="card-text">
           And we want to increase developer happiness. It should be a pleasure
           to use Flix!
         </p>
@@ -410,13 +410,13 @@ import Question from "../components/FAQ/Question.astro";
         minutes.
       </Question>
       <div>
-        <p>
+        <p class="card-text">
           We much prefer <a
             href="https://en.wikipedia.org/wiki/Cholula_Hot_Sauce"
             >Cholula Hot Sauce.</a
           >
         </p>
-        <p>
+        <p class="card-text">
           That said, <code>forM</code> is clear, concise, and works well with <code
             >forA</code
           > allowing one to easily switch between monadic-code and applicative-code.
@@ -430,7 +430,7 @@ import Question from "../components/FAQ/Question.astro";
         symbols.
       </Question>
       <div>
-        <p>
+        <p class="card-text">
           The Flix syntax is <a href="/principles/">based on keywords</a> except when
           there is a
           <i>clearly established historical precedent</i> for using a symbol. For

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -99,7 +99,7 @@ const vscodeSlides = [
             <div class="card-title">
               <h4>Algebraic Data Types and Pattern Matching</h4>
             </div>
-            <p>
+            <p class="card-text">
               Algebraic data types and pattern matching are the bread-and-butter
               of functional programming and are supported by Flix with minimal
               fuss.
@@ -114,8 +114,8 @@ const vscodeSlides = [
         <div class="card border-0">
           <div class="card-body">
             <div class="card-title"><h4>Tuples and Records</h4></div>
-            <p>Flix has built-in support for tuples and records.</p>
-            <p>Records use structural typing and are extensible.</p>
+            <p class="card-text">Flix has built-in support for tuples and records.</p>
+            <p class="card-text">Records use structural typing and are extensible.</p>
           </div>
         </div>
       </div>
@@ -132,10 +132,10 @@ const vscodeSlides = [
         <div class="card border-0">
           <div class="card-body">
             <div class="card-title"><h4>Purity and Impurity</h4></div>
-            <p>
+            <p class="card-text">
               Flix precisely tracks the purity of every expression in a program.
             </p>
-            <p>
+            <p class="card-text">
               The Flix compiler provides an ironclad guarantee that if an
               expression is pure then it cannot have side-effects and it is
               referentially transparent.
@@ -150,11 +150,11 @@ const vscodeSlides = [
         <div class="card border-0">
           <div class="card-body">
             <div class="card-title"><h4>Polymorphic Effects</h4></div>
-            <p>
+            <p class="card-text">
               Flix is able to track purity through higher-order effect
               polymorphic functions.
             </p>
-            <p>
+            <p class="card-text">
               For example, Flix knows that the purity of <code>List.map</code> depends
               on the purity of its function argument <code>f</code>.
             </p>
@@ -174,16 +174,16 @@ const vscodeSlides = [
         <div class="card border-0">
           <div class="card-body">
             <div class="card-title"><h4>Algebraic Effects</h4></div>
-            <p>
+            <p class="card-text">
               Flix supports algebraic effects, i.e. user-defined effects and
               handlers. In particular, Flix supports multi-shot resumptions.
             </p>
-            <p>
+            <p class="card-text">
               Effect-oriented programming, with algebraic effects, allows
               programmers to write pure functions modulo effects. Effect
               handlers enable program reasoning, modularity, and testability.
             </p>
-            <p>
+            <p class="card-text">
               For example, the program on the left expresses a <code
                 >greeting</code
               > function that is pure modulo the current time of the day. In <code
@@ -203,18 +203,18 @@ const vscodeSlides = [
         <div class="card border-0">
           <div class="card-body">
             <div class="card-title"><h4>Library Effects</h4></div>
-            <p>
+            <p class="card-text">
               The Flix Standard Library comes with a rich collection of
               built-in effects, including <code>Clock</code>, <code>Console</code
               >, <code>Env</code>, <code>FileSystem</code>, <code>Http</code>, <code
                 >Logger</code
               >, <code>Process</code>, and <code>Random</code>.
             </p>
-            <p>
+            <p class="card-text">
               Every library effect has a default handler, hence programs can
               use them without any handler boilerplate.
             </p>
-            <p>
+            <p class="card-text">
               Library effects support composable middleware: HTTP requests can
               be configured with retries and circuit breakers, and the
               filesystem can be sandboxed, made read-only, or replaced with an
@@ -236,18 +236,18 @@ const vscodeSlides = [
         <div class="card border-0">
           <div class="card-body">
             <div class="card-title"><h4>Region-based Local Mutation</h4></div>
-            <p>
+            <p class="card-text">
               Flix supports region-based local mutation, which makes it possible
               to implement <i>pure</i> functions that internally use mutable state
               and destructive operations, as long as these operations are confined
               to the region.
             </p>
-            <p>
+            <p class="card-text">
               We can use local mutation when it is more natural to write a
               function using mutable data and in a familiar imperative-style
               while still remaining pure to the outside world.
             </p>
-            <p>
+            <p class="card-text">
               We can also use local mutation when it is more efficient to use
               mutable data structures, e.g. when implementing a sorting
               algorithm.
@@ -262,19 +262,19 @@ const vscodeSlides = [
         <div class="card border-0">
           <div class="card-body">
             <div class="card-title"><h4>Mutable Structs</h4></div>
-            <p>
+            <p class="card-text">
               Flix supports mutable structs. Fields are immutable by
               default, but can be marked with the <code>mut</code> modifier.
               Like all mutable memory in Flix, every struct belongs to a
               region.
             </p>
-            <p>
+            <p class="card-text">
               Struct fields are unboxed, i.e. primitive fields do not require
               indirection. This makes structs a memory efficient building
               block for higher-level data structures, e.g. mutable lists,
               stacks, and queues.
             </p>
-            <p>
+            <p class="card-text">
               The fields of a struct are only visible from within its
               companion module, providing compiler-enforced encapsulation.
             </p>
@@ -294,17 +294,17 @@ const vscodeSlides = [
         <div class="card border-0">
           <div class="card-body">
             <div class="card-title"><h4>Purity Reflection</h4></div>
-            <p>
+            <p class="card-text">
               Flix supports a meta-programming construct that enables
               higher-order functions to inspect the purity of a function
               argument and use that information to vary their behavior.
             </p>
-            <p>
+            <p class="card-text">
               For example, the <code>DelayList.map</code> function varies its behavior
               between eager and lazy evaluation depending on the purity of its function
               argument.
             </p>
-            <p>
+            <p class="card-text">
               We can exploit purity reflection to selectively use lazy or
               parallel evaluation inside a library without changing the
               semantics from the point-of-view of the clients.
@@ -319,14 +319,14 @@ const vscodeSlides = [
         <div class="card border-0">
           <div class="card-body">
             <div class="card-title"><h4>Parallelism</h4></div>
-            <p>
+            <p class="card-text">
               Flix makes it simple and easy to evaluate <i>pure</i> code in parallel.
             </p>
-            <p>
+            <p class="card-text">
               For example, the code on the right shows a parallel implementation
               of the <code>List.map</code> function using the <code>par</code> construct.
             </p>
-            <p>
+            <p class="card-text">
               Internally, the <code>par</code> construct uses light-weight <code
                 >VirtualThread</code
               >s.
@@ -347,17 +347,17 @@ const vscodeSlides = [
         <div class="card border-0">
           <div class="card-body">
             <div class="card-title"><h4>Structured Concurrency</h4></div>
-            <p>
+            <p class="card-text">
               Flix supports <a
                 href="https://vorpus.org/blog/notes-on-structured-concurrency-or-go-statement-considered-harmful/"
                 >structured concurrency</a
               >.
             </p>
-            <p>
+            <p class="card-text">
               For example, the code on the left shows the creation of a fresh
               region named <code>rc</code> in which two threads are spawned.
             </p>
-            <p>
+            <p class="card-text">
               Importantly, control-flow does not leave the region before <i
                 >both</i
               > threads have terminated. Hence the two threads cannot outlive the
@@ -373,11 +373,11 @@ const vscodeSlides = [
         <div class="card border-0">
           <div class="card-body">
             <div class="card-title"><h4>Traits</h4></div>
-            <p>
+            <p class="card-text">
               Flix uses traits to abstract over types that support a common set
               of operations.
             </p>
-            <p>
+            <p class="card-text">
               For example, the <code>Eq</code> trait captures the notion of equality
               and is used throughout the standard library.
             </p>
@@ -397,13 +397,13 @@ const vscodeSlides = [
         <div class="card border-0">
           <div class="card-body">
             <div class="card-title"><h4>Higher-Kinded Types</h4></div>
-            <p>
+            <p class="card-text">
               Flix supports higher-kinded types making it possible to abstract
               over type constructors. For example, both <code>Option</code> and <code
                 >List</code
               > implement <code>Foldable</code>.
             </p>
-            <p>
+            <p class="card-text">
               The Flix standard library ships with many common traits, such as <code
                 >Monoid</code
               >, <code>Functor</code>, and <code>Foldable</code>.
@@ -418,11 +418,11 @@ const vscodeSlides = [
         <div class="card border-0">
           <div class="card-body">
             <div class="card-title"><h4>Associated Types</h4></div>
-            <p>
+            <p class="card-text">
               Flix supports associated types, which allow the types in instance
               signatures to depend on the instance type.
             </p>
-            <p>
+            <p class="card-text">
               The code on the right defines a trait with an associated type <code
                 >Elm</code
               >, which enables each <code>Coll</code> instance to define its element
@@ -444,13 +444,13 @@ const vscodeSlides = [
         <div class="card border-0">
           <div class="card-body">
             <div class="card-title"><h4>Associated Effects</h4></div>
-            <p>
+            <p class="card-text">
               Associated effects allow the effects in trait members to depend on
               the instance type. This makes it easy to create abstractions over
               both pure and effectful operations, and mutable and immutable data
               structures.
             </p>
-            <p>
+            <p class="card-text">
               The code on the left adds an associated effect <code>Aef</code> to
               the <code>Coll</code> trait, which makes it possible to add
               instances for mutable collections.
@@ -465,7 +465,7 @@ const vscodeSlides = [
         <div class="card border-0">
           <div class="card-body">
             <div class="card-title"><h4>Monadic For-Yield</h4></div>
-            <p>
+            <p class="card-text">
               Flix supports a monadic <code>forM</code>-yield construct similar
               to Scala's
               <code>for</code>-comprehensions and Haskell's <code>do</code> notation.
@@ -491,7 +491,7 @@ const vscodeSlides = [
         <div class="card border-0">
           <div class="card-body">
             <div class="card-title"><h4>Applicative For-Yield</h4></div>
-            <p>
+            <p class="card-text">
               In addition to the monadic <code>forM</code> expression, Flix supports
               an applicative <code>forA</code> expression that builds on the <code
                 >Applicative</code
@@ -510,12 +510,12 @@ const vscodeSlides = [
             <div class="card-title">
               <h4>Seamless Java Interoperability</h4>
             </div>
-            <p>
+            <p class="card-text">
               Flix supports seamless Java interoperability, making it possible
               to reuse code from the Java Standard Library and the Java
               ecosystem, e.g., via Maven.
             </p>
-            <p>
+            <p class="card-text">
               Java support includes object creation, method invocation,
               exceptions, and class/interface extension.
             </p>
@@ -535,13 +535,13 @@ const vscodeSlides = [
         <div class="card border-0">
           <div class="card-body">
             <div class="card-title"><h4>Termination Checking</h4></div>
-            <p>
+            <p class="card-text">
               Flix supports the <code>@Terminates</code> annotation, which
               asks the compiler to verify that a function is structurally
               recursive &mdash; and hence guaranteed to terminate on all
               inputs.
             </p>
-            <p>
+            <p class="card-text">
               The compiler checks that every recursive call is on a strict
               substructure of a formal parameter. The check supports tree
               recursion, functions with multiple parameters, local
@@ -559,7 +559,7 @@ const vscodeSlides = [
             <div class="card-title">
               <h4>First-class Datalog Constraints</h4>
             </div>
-            <p>
+            <p class="card-text">
               Another unique feature of Flix is its embedded Datalog support.
               Datalog, a powerful logic programming language in its own right,
               makes it simple and elegant to express many fixpoint problems
@@ -584,10 +584,10 @@ const vscodeSlides = [
             <div class="card-title">
               <h4>Datalog Enriched with Lattice Semantics</h4>
             </div>
-            <p>
+            <p class="card-text">
               Flix supports Datalog constraints enriched with lattice semantics.
             </p>
-            <p>
+            <p class="card-text">
               The program on the right computes the delivery date for a
               collection of parts. Each part is assembled from a collection of
               sub-components with various delivery dates. For example, a car
@@ -595,13 +595,13 @@ const vscodeSlides = [
               wait for the chassis and engine to be assembled and then we can
               assemble the car itself.
             </p>
-            <p>
+            <p class="card-text">
               Note that parts may depend on sub-components that themselves may
               depend on other sub-components. In other words, the problem is
               recursive.
             </p>
             <hr />
-            <p>
+            <p class="card-text">
               Support for Datalog constraints enriched with lattice semantics is
               one of the more advanced features of Flix and requires some
               background knowledge of lattice theory and fixpoints.

--- a/src/pages/principles.astro
+++ b/src/pages/principles.astro
@@ -380,20 +380,20 @@ import Principle from "../components/Principle.astro"
 
     <div class="card-columns">
         <Principle name="The 80 / 20 Rule">
-            <p>
+            <p class="card-text">
                 The rule states that 80% of the time a developer will need minimal information to understand
                 a compiler message. Most likely the developer will already have seen the specific
                 error message hundreds of times before. But 20% of the time, the developer will
                 never have seen the message before and will need more information.
             </p>
 
-            <p>
+            <p class="card-text">
                 Flix compiler messages should accommodate both scenarios.
             </p>
         </Principle>
 
         <Principle name="Message Structure">
-            <p>
+            <p class="card-text">
                 A compiler message consists of three components:
 
                 <ul>
@@ -411,7 +411,7 @@ import Principle from "../components/Principle.astro"
         </Principle>
 
         <Principle name="Style and Tone">
-            <p>
+            <p class="card-text">
                 A message should be <b>crisp</b>, <b>concise</b>, and <b>clear</b>.
                 The language should be friendly or neutral. An error message should not blame
                 the programmer. For example, we should prefer <code>Unexpected foo</code> over <code>Illegal
@@ -420,7 +420,7 @@ import Principle from "../components/Principle.astro"
         </Principle>
 
         <Principle name="Straight to the Point">
-            <p>
+            <p class="card-text">
                 The error message: <code>Duplicate definition: 'foo'</code> is better than the error
                 message: <code>The definition 'foo' is defined twice</code> because in the former the
                 programmer only has to scan the first word to understand what is wrong.
@@ -428,7 +428,7 @@ import Principle from "../components/Principle.astro"
         </Principle>
 
         <Principle name="Compare to Other Languages">
-            <p>
+            <p class="card-text">
                 When relevant, a Flix compiler error should explain how Flix differs from other languages
                 and explain how the specific problem can be solved in Flix.
             </p>
@@ -439,12 +439,12 @@ import Principle from "../components/Principle.astro"
 
     <div class="card-columns">
         <Principle name="Type Classes are Conceptually Functions">
-            <p>
+            <p class="card-text">
                 A type class is <i>conceptually</i> a function from a type to a set of lawful
                 operations (called signatures) on values of that type.
             </p>
 
-            <p>
+            <p class="card-text">
                 For example, the <code>Eq</code> type class takes a type and returns
                 the <code>eq</code> and <code>neq</code> functions where <code>eq</code> must be reflexive,
                 symmetric, and transitive, and <code>neq</code> must be
@@ -453,12 +453,12 @@ import Principle from "../components/Principle.astro"
         </Principle>
 
         <Principle name="Lawful and Lawless Type Classes">
-            <p>
+            <p class="card-text">
                 Every type class must specify a collection of laws that instances of the type
                 class must satisfy. If a type class does not specify any laws it is lawless.
             </p>
 
-            <p>
+            <p class="card-text">
                 Here are some examples of lawful and lawless type classes:
 
                 <ul>
@@ -468,11 +468,11 @@ import Principle from "../components/Principle.astro"
                 </ul>
             </p>
 
-            <p>
+            <p class="card-text">
                 A type class is lawful if every signature of the class is used in at least one law.
             </p>
 
-            <p>
+            <p class="card-text">
                 Note: Laws are not checked by the compiler &ndash; that is an undecidable
                 problem &ndash; but they may be used in a future SmallCheck / QuickCheck library.
             </p>
@@ -480,12 +480,12 @@ import Principle from "../components/Principle.astro"
         </Principle>
 
         <Principle name="Type Classes are Hierarchical">
-            <p>
+            <p class="card-text">
                 A sub-class (i.e. a type class <code>A</code> that refines a type class <code>B</code>) must
                 specify additional laws that its instances must satisfy.
             </p>
 
-            <p>
+            <p class="card-text">
                 For example, the <code>Applicative</code> type class extends the <code>Functor</code> type
                 class with additional operations and laws.
             </p>
@@ -507,22 +507,22 @@ import Principle from "../components/Principle.astro"
         </Principle>
 
         <Principle name="No Overlapping Instances">
-            <p>
+            <p class="card-text">
                 The Flix compiler ensures that the selection of type class instances is always unambiguous.
             </p>
 
-            <p>
+            <p class="card-text">
                 In the future, we may allow a limited form of overlapping instances.
             </p>
         </Principle>
 
         <Principle name="Type Classes, Namespaces, and Companion Namespaces">
-            <p>
+            <p class="card-text">
                 Every type class belongs to a namespace. Hence it is possible to define multiple operations
                 with the same name, as long as they belong to type classes in different namespaces.
             </p>
 
-            <p>
+            <p class="card-text">
                 Every type class also defines a <i>companion namespace</i> which typically holds functions
                 that are not part of the type class, but nevertheless are related to the functionality of
                 the type class.
@@ -530,17 +530,17 @@ import Principle from "../components/Principle.astro"
         </Principle>
 
         <Principle name="Default Implementations">
-            <p>
+            <p class="card-text">
                 Type classes may provide default implementations of functions.
             </p>
 
-            <p>
+            <p class="card-text">
                 For example, the <code>Foldable</code> type class may provide default function
                 implementations, e.g. <code>count</code> and <code>length</code>, based on
                 the <code>foldLeft</code> and <code>foldRight</code> signatures defined in that class.
             </p>
 
-            <p>
+            <p class="card-text">
                 A default implementation can always be overriden by a specific type class instance.
                 For example, to provide a more efficient version.
             </p>

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -62,16 +62,6 @@ h4, .h4 {
     font-size: 1.5rem;
 }
 
-/* A card sizes itself to its contents, so the last paragraph's bottom margin
-   becomes dead space inside the border. Bootstrap solves this with
-   .card-text:last-child, but the site writes plain <p> inside .card-body, and
-   in the FAQ they sit one <div> further in, so match on the container instead.
-   Anywhere else the margin is wanted: it is what separates a column's last
-   paragraph from whatever the next row brings. */
-.card-body p:last-child {
-    margin-bottom: 0;
-}
-
 .menu {
     /* Bleed the navbar back out over the container's padding so it spans the
        full width of the page card. Deriving it from the gutter keeps the two

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -62,7 +62,13 @@ h4, .h4 {
     font-size: 1.5rem;
 }
 
-p:last-child {
+/* A card sizes itself to its contents, so the last paragraph's bottom margin
+   becomes dead space inside the border. Bootstrap solves this with
+   .card-text:last-child, but the site writes plain <p> inside .card-body, and
+   in the FAQ they sit one <div> further in, so match on the container instead.
+   Anywhere else the margin is wanted: it is what separates a column's last
+   paragraph from whatever the next row brings. */
+.card-body p:last-child {
     margin-bottom: 0;
 }
 
@@ -120,10 +126,6 @@ p:last-child {
 .code-snippet-code pre {
     margin: 0;
     background: transparent !important;
-}
-
-.nav-item {
-    cursor: pointer;
 }
 
 /* Mark the current page with the brand red as well as weight and brightness.


### PR DESCRIPTION
Follow-up to #197. Two leftovers from the Bootstrap 4 days, found while auditing what `global.css` still overrides. Both end with the site owning less CSS than before.

### `p:last-child` deleted; card paragraphs marked `.card-text`

The rule was written for cards, where the last paragraph's bottom margin becomes dead space inside the border. It was never scoped, so it also fired on the last paragraph of a column — and there the margin is wanted, since it is what holds the intro copy off the heading, rule, or screenshot the next row brings.

Bootstrap already ships this exact rule as `.card-text:last-child`, keyed on the paragraph rather than the container. 98 paragraphs across the home, FAQ, principles, and contribute pages were missing the class; with it added, the site needs no rule of its own.

Every card paragraph is marked, not only the ones currently last. `.card-text` does nothing else — zeroing that margin is its entire definition — so the extras cost nothing, and the next person to append a paragraph to a card gets the right behaviour instead of silently reintroducing the gap.

### `.nav-item { cursor: pointer }` deleted

Dates from when Bootstrap 4 drove tabs from JS on the `<li>`. The link inside is an `<a href>`, which the browser already gives a pointer cursor. All the rule did was promise a pointer on the 4px of `ps-1`/`pe-1` padding either side of each nav item, where clicking does nothing.

### Verification

All nine pages screenshot before and after and diffed as images — layout-identical, the two card-only pages (FAQ, principles) included. The one region that moved is the code-snippet scrollbar thumb on the home page, which differs between two runs of the *same* build, so it is renderer noise rather than a change.

The paragraph count was arrived at twice independently — parsing the rendered HTML for `<p>` inside `.card-body`, and parsing the `.astro` sources for `<p>` inside `<QA>` / `<Principle>` / `.card-body` — and both give 98. `astro check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)