### PR TITLE
feat: lay out the VSCode features as a two-column grid

### DIFF
--- a/src/pages/vscode.astro
+++ b/src/pages/vscode.astro
@@ -61,16 +61,20 @@ const features = [
       </div>
     </div>
 
-    {features.map((f, i) => (
-      <div class="row mb-5">
-        <div class="col-md-6">
-          <h4>{f.title}</h4>
-          <p set:html={f.desc}></p>
-          <div class="card">
-            <img class="card-img-top" src={f.img} alt={f.alt} loading={i === 0 ? "eager" : "lazy"} />
+    {/* Two per row from md up. The cards stretch to the tallest in the row, so
+        the screenshots line up along the bottom however long the prose runs. */}
+    <div class="row row-cols-1 row-cols-md-2 g-4 mb-5">
+      {features.map((f, i) => (
+        <div class="col">
+          <div class="card h-100">
+            <div class="card-body">
+              <h4 class="card-title">{f.title}</h4>
+              <p class="card-text mb-0" set:html={f.desc}></p>
+            </div>
+            <img class="card-img-bottom" src={f.img} alt={f.alt} loading={i < 2 ? "eager" : "lazy"} />
           </div>
         </div>
-      </div>
-    ))}
+      ))}
+    </div>
   </div>
 </Layout>


### PR DESCRIPTION
The VSCode page listed its seven features as seven separate `row`s, each holding one `col-md-6`. Every screenshot sat in the left half of the page with the right half blank, so the page was about twice as long as it needed to be. This folds them into a single `row-cols-1 row-cols-md-2` grid: one per row on phones, two from `md` up.

### Why

The screenshots are all 502x214. A card in an `md` column of the site container is roughly 525px wide, so in a two-up grid they render at about native size — the half-width column was never buying them anything. Nothing was gained by the vertical stack except scrolling.

The old markup also split each feature across two boxes: an `h4` and a `<p>` floating above, then a bordered `card` holding only the image. Making the whole feature one card groups the title, the description and the thing they describe.

`h-100` on the cards plus the flexing `card-body` keeps the screenshots aligned along the bottom of each row. That matters here because the descriptions are uneven — "Snippet Completion" and "Hover" run to two lines at desktop width while "Inline Diagnostics" is five words — and without it the images would sit at different heights side by side.

### What changed

- `vscode.astro` — the seven `row`s collapse to one `row row-cols-1 row-cols-md-2 g-4`; the per-row `mb-5` is replaced by the `g-4` gutter
- each feature becomes a single `card h-100` with the title and description in `card-body` and the screenshot as `card-img-bottom`
- the title is now `h4.card-title` (1.2rem via `global.css`, down from 1.5rem), which suits the denser tile
- the first *two* images load eagerly rather than just the first, since two are above the fold together

### Notes

Seven features means the last row has one card and an empty half. Easy to change if it looks wrong — drop one, add an eighth, or let the last card span the full width — but I left it alone rather than guess.

`npm run build` is clean across all ten pages, and the `<code>` in the Quick Fixes description still renders through `set:html`. I did not view this in a browser: there is no headless browser installed in this environment, so the alignment claims above are from the Bootstrap semantics rather than from looking at it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)