### PR TITLE
chore: quiet the typography in the home page intro

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -43,11 +43,11 @@ const vscodeSlides = [
     <div class="row mb-3">
       <div class="col-md-6">
         <h1>Flix &mdash;</h1>
-        <h2 class="motto">
+        <h5>
           A powerful <span class="fw-bold text-success"
             >effect-oriented</span
           > programming language
-        </h2>
+        </h5>
         <p>
           Flix is a principled effect-oriented functional, imperative, and logic
           programming language developed at <a href="https://cs.au.dk/"
@@ -57,7 +57,7 @@ const vscodeSlides = [
             >open source contributors</a
           >.
         </p>
-        <h4>Why effect-oriented? And why Flix?</h4>
+        <h5>Why effect-oriented? And why Flix?</h5>
         <p>
           <span class="fst-italic">Why Effects?</span> Effect systems represent the
           next major evolution in statically typed programming languages. By explicitly
@@ -67,19 +67,15 @@ const vscodeSlides = [
         </p>
         <p>
           <span class="fst-italic">Why Flix?</span> We claim that of all the upcoming
-          effect-oriented programming languages, Flix offers the most <strong
-            >complete language implementation</strong
-          >, the most <strong>extensive standard library</strong>, the most <strong
-            >detailed documentation</strong
-          >, and the <strong>best tool support.</strong>
+          effect-oriented programming languages, Flix offers the most complete
+          language implementation, the most extensive standard library, the most
+          detailed documentation, and the best tool support.
         </p>
         <p>
           Moreover, Flix builds on proven programming language technology,
-          including: <strong>algebraic data types and pattern matching</strong>, <strong
-            >extensible records</strong
-          >, <strong>traits</strong>, <strong>higher-kinded types</strong>, <strong
-            >associated types and effects</strong
-          >, <strong>structured concurrency</strong>, and more.
+          including: algebraic data types and pattern matching, extensible
+          records, traits, higher-kinded types, associated types and effects,
+          structured concurrency, and more.
         </p>
       </div>
       <div class="col-md-6">

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -89,10 +89,6 @@ h4, .h4 {
     min-height: 95vh;
 }
 
-.motto {
-    font-size: 1.35rem;
-}
-
 .code-snippet-frame {
     margin-top: 1em;
     margin-bottom: 1.5em;


### PR DESCRIPTION
The left column of the home page intro was competing with itself: two headings at three sizes, a green highlight, italic lead-ins, and two paragraphs that were more than half bold. This turns the volume down without touching a word of the copy.

### Why

**The bold had stopped meaning anything.** In *Moreover, Flix builds on proven programming language technology*, 17 of the paragraph's 29 words sat inside a `<strong>` — about 60% of it. The paragraph above was a third bold. Emphasis works by contrast with what surrounds it, and past roughly half a paragraph there is nothing left to contrast against; it just reads as a heavy block.

Softening the weight was not an option. Bootstrap's reboot sets `b, strong { font-weight: bolder }`, which against the 400 body resolves to 700, and `Layout.astro` loads only the 400 and 700 Open Sans subsets. A `fw-semibold` would have been a no-op — CSS font-matching sends a requested 600 up to the 700 that is actually there. Getting a lighter step would have meant shipping two more woff2 files to fix a problem that was really about coverage, not weight. So the bold is simply gone.

Both paragraphs still have their italic *Why Effects?* and *Why Flix?* lead-ins, which is what actually labels them.

**The `.motto` rule only ever shrank its own element.** It set `font-size: 1.35rem` on an `<h2>` that `global.css` otherwise renders at 1.7rem — a one-use class whose entire job was to undo the tag it was attached to. Using an `<h5>` says the same thing with no CSS, and the rule is deleted. `global.css` is now 152 lines.

### What changed

- `index.astro` — `<h2 class="motto">` and `<h4>Why effect-oriented? And why Flix?</h4>` both become `<h5>`
- `index.astro` — all eleven `<strong>` runs removed from the *Why Flix?* and *Moreover* paragraphs; no wording changed
- `global.css` — the `.motto` rule deleted

### Notes

Two deliberate consequences worth checking in the browser. The motto goes from 1.35rem to Bootstrap's 1.25rem, and the heading below it from 1.5rem to the same 1.25rem — so the two headings now render at identical size, where before the lower one was larger than the motto. If you would rather keep them distinct, the second one can go back to `h6` or stay at `h4`.

The green `fw-bold text-success` spans are all untouched, here and further down the page. Those are a brand highlight rather than emphasis inside body copy, so they seemed like a separate decision.

`npm run build` is clean across all ten pages, with no `strong` or `motto` left in the output. Not viewed in a browser — no headless browser in this environment — so the size claims above come from the stylesheet rather than from looking at it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)