### PR TITLE
chore: tighten the spacing under the get started intro

### DIFF
--- a/src/pages/get-started.astro
+++ b/src/pages/get-started.astro
@@ -9,7 +9,7 @@ import Layout from "../layouts/Layout.astro";
   <div class="container">
     <h1>Get Started</h1>
 
-    <div class="row mb-5">
+    <div class="row mb-1">
       <div class="col">
         <p>
           We recommend using Flix from Visual Studio Code. In addition, Flix


### PR DESCRIPTION
The intro paragraph on the Get Started page sat on `mb-5`, leaving a 3rem gap before the "Installing the Flix Visual Studio Code Extension" heading. Now `mb-1` (0.25rem).

One line, `src/pages/get-started.astro:12` — the only `mb-5` in the file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
