### PR TITLE
fix: stop the code boxes growing a vertical scrollbar

### DIFF
--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -94,10 +94,15 @@ h4, .h4 {
     margin-bottom: 1.5em;
 }
 
+/* No overflow here on purpose. Astro ships the <pre> with its own inline
+   overflow-x:auto, so a scroller here would be the second of two nested ones,
+   and that is what put a vertical scrollbar on the wider snippets. Scrolling
+   the <pre> instead also keeps the side padding as a fixed gutter rather than
+   letting the left one scroll away and the code run flush to the edge. The
+   bottom padding lives on the <pre> for the same reason. */
 .code-snippet-code {
-    padding: 1em 1.75em;
+    padding: 0.9em 1.6em 0;
     background-color: #f7f7f7;
-    overflow-x: auto;
 }
 
 .code-snippet-code pre,
@@ -109,9 +114,17 @@ h4, .h4 {
     line-height: 14px;
 }
 
+/* overflow-x:auto arrives inline from Astro. overflow-y has to be stated: left
+   at its initial `visible` the spec promotes it to `auto` alongside a non-visible
+   x, and the horizontal scrollbar - laid out inside the box - then steals just
+   enough height to trigger the vertical one. The padding-bottom is where that
+   scrollbar sits, so it covers padding instead of the last line of code; the box
+   looks the same as before when no scrollbar is present. */
 .code-snippet-code pre {
     margin: 0;
     background: transparent !important;
+    overflow-y: hidden;
+    padding-bottom: 0.9em;
 }
 
 /* Mark the current page with the brand red as well as weight and brightness.


### PR DESCRIPTION
The wider snippets showed a vertical scrollbar they had no use for. Two causes, both from overflow nobody quite wrote.

### What was happening

Astro ships the `<pre>` with an inline `overflow-x: auto` of its own:

```html
<div class="code-snippet-code">                     <!-- overflow-x: auto  (global.css) -->
  <pre style="...; overflow-x: auto;" tabindex="0">  <!-- overflow-x: auto  (Astro, inline) -->
```

So the code boxes were **two nested scroll containers**, the outer one redundant. And neither states `overflow-y`, so per the [CSS overflow spec](https://drafts.csswg.org/css-overflow-3/#overflow-properties) the initial `visible` is promoted to `auto` when the other axis is not visible. The horizontal scrollbar is then laid out inside the box and steals just enough height to trip the vertical one.

That is why it was only *some* boxes — it tracks the ones wide enough to scroll horizontally. At 12px Monaco inside a `col-md-6`, roughly:

| Viewport | Fits | Snippets that overflow |
| --- | --- | --- |
| ~1440px | ~79 ch | none |
| ~1280px | ~67 ch | `httpExample` |
| ~1024px | ~54 ch | 13 of 22 |
| ~800px | ~38 ch | nearly all |

### The fix

- Drop the outer scroller; let the `<pre>` be the only one.
- State `overflow-y: hidden` on it, since leaving it implicit is what created the second axis.
- Move the bottom padding from the div onto the `<pre>`, so the horizontal scrollbar has somewhere to sit that isn't the last line of code. `overflow-y: hidden` on its own would have traded the stray scrollbar for a clipped last line.

Bottom spacing is unchanged when no scrollbar is present. Keeping the scroller on the `<pre>` rather than the div is also the nicer of the two: the side padding stays a fixed gutter, instead of the left one scrolling away and the code running flush to the edge when you scroll right.

Side padding is also trimmed from `1em 1.75em` to `0.9em 1.6em`, as discussed separately.

### Reviewing it

This only reproduces where scrollbars take layout space — macOS overlay scrollbars occupy none, so you need *System Settings → Appearance → Show scroll bars: Always*, or Windows/Linux. Good places to look are `httpExample` at ~1280px, or most of the home page around ~1024px: the horizontal bar should sit in the padding with the last code line fully visible, and no vertical bar.

`npm run build` passes; all 10 pages generate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
