### PR TITLE
chore: remove the now-unused lattice example

### DIFF
--- a/src/lib/indexExamples.js
+++ b/src/lib/indexExamples.js
@@ -321,33 +321,3 @@ export const datalogExample = `def reachable(g: List[(String, Int32, String)], m
         Path(x, z) :- Path(x, y), Road(y, maxSpeed, z), if maxSpeed >= minSpeed.
     };
     query facts, rules select (src, dst) from Path(src, dst) |> Foldable.toList`;
-
-export const latticeExample = `let p = #{
-    /// Parts and the components they depend on.
-    PartDepends("Car",       "Chassis").
-    PartDepends("Car",       "Engine").
-    PartDepends("Engine",    "Piston").
-    PartDepends("Engine",    "Ignition").
-
-    /// Time required to assemble a part from its components.
-    AssemblyTime("Car",     7).
-    AssemblyTime("Engine",  2).
-
-    /// Expected delivery date for certain components.
-    DeliveryDate("Chassis";  2).
-    DeliveryDate("Piston";   1).
-    DeliveryDate("Ignition"; 7).
-
-    /// A part is ready when it is delivered.
-    ReadyDate(part; date) :-
-        DeliveryDate(part; date).
-
-    /// Or when it can be assembled from its components.
-    ReadyDate(part; assemblyTime + componentDate) :-
-        PartDepends(part, component),
-        AssemblyTime(part, assemblyTime),
-        ReadyDate(component; componentDate).
-};
-
-// Computes the delivery date for each component.
-let r = query p select (c, d) from ReadyDate(c; d)`;


### PR DESCRIPTION
Follow-up to #205. That PR dropped the "Datalog Enriched with Lattice Semantics" section from the home page but left `latticeExample` exported from `src/lib/indexExamples.js` with no remaining users. This removes it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)