### PR TITLE
chore: cache npm deps in CI and update actions to v7

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -28,11 +28,12 @@ jobs:
         node-version: [22.x, 24.x]
 
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v7
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@v7
         with:
           node-version: ${{ matrix.node-version }}
+          cache: npm
       - run: npm ci
       - run: npm run check
       - run: npm run build


### PR DESCRIPTION
Adds `cache: npm` to `actions/setup-node` so `npm ci` restores package tarballs from cache rather than re-downloading them on every run. The cache key defaults to `package-lock.json` at the repo root. Both matrix legs share a single cache entry — setup-node caches `~/.npm`, npm's content-addressed tarball store, which is independent of the Node version.

Also bumps the actions to their current majors:

- `actions/checkout` v5 -> v7
- `actions/setup-node` v6 -> v7

Neither major affects this workflow. setup-node v7 is an ESM and dependency migration with `cache` behaviour unchanged; checkout v6/v7 only change credential storage and fork checkout under `pull_request_target` / `workflow_run`, which this workflow does not use.

On timing: this PR's own run was a cache miss that populated the cache, and that entry is scoped to `refs/pull/207/merge`, so it is discarded when the PR closes. The durable win starts after this lands and a master build populates the base-branch cache, which later PRs can then read. Expect it to stay modest either way — most of the ~30s run is the Astro build, not `npm ci`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)