### PR TITLE
feat: list the effect, region, struct, and termination features

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -584,6 +584,7 @@ const vscodeSlides = [
           <li>pattern matching</li>
           <li>first-class functions</li>
           <li>extensible records</li>
+          <li>mutable structs</li>
           <li>parametric polymorphism</li>
           <li>traits (i.e. type classes)</li>
           <li>automatic trait derivation</li>
@@ -593,9 +594,10 @@ const vscodeSlides = [
       </div>
       <div class="col-md-4">
         <ul>
-          <li>effect polymorphism + subeffecting</li>
+          <li>algebraic effects and handlers</li>
           <li>default effect handlers</li>
           <li>purity reflection</li>
+          <li>region-based local mutation</li>
           <li>CSP-style concurrency</li>
           <li>buffered &amp; unbuffered channels</li>
           <li>first-class datalog constraints</li>
@@ -610,6 +612,7 @@ const vscodeSlides = [
           <li>applicative forA expressions</li>
           <li>string interpolation</li>
           <li>expression holes</li>
+          <li>termination checking</li>
           <li>compilation to JVM bytecode</li>
           <li>full tail call elimination</li>
           <li>resilient compiler architecture</li>


### PR DESCRIPTION
The Complete Feature List omitted four features that the home page demonstrates in its own cards further up:

| Feature | Demoed at |
|---|---|
| algebraic effects and handlers | "Algebraic Effects" |
| region-based local mutation | "Region-based Local Mutation" |
| mutable structs | "Mutable Structs" |
| termination checking | "Termination Checking" |

This adds all four, and drops `effect polymorphism + subeffecting` in the same pass.

## Layout

The three columns were 9/9/9 and are now 10/10/10, so nothing about the row's shape changes:

```
algebraic data types          algebraic effects and handlers       monadic forM expressions
pattern matching              default effect handlers              applicative forA expressions
first-class functions         purity reflection                    string interpolation
extensible records            region-based local mutation          expression holes
mutable structs               CSP-style concurrency                termination checking
parametric polymorphism       buffered & unbuffered channels       compilation to JVM bytecode
traits (i.e. type classes)    first-class datalog constraints      full tail call elimination
automatic trait derivation    seamless interoperability with Java  resilient compiler architecture
higher-kinded types           unboxed primitives                   parallel compiler architecture
associated types and effects  keyword-based syntax                 human-friendly errors
```

Each entry sits next to the ones it relates to: effects and handlers heads the effect column, region-based mutation follows purity reflection, mutable structs follow extensible records, and termination checking joins the static-checking entries.

`npm run check` and `npm run build` both pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)