### PR TITLE
fix: restore spaces lost between inline elements

### DIFF
--- a/src/pages/404.astro
+++ b/src/pages/404.astro
@@ -12,12 +12,14 @@ import Layout from '../layouts/Layout.astro';
         <h1>Page Not Found</h1>
         <p>Sorry, the page you are looking for does not exist.</p>
         <p>
-          Head back to the <a href="/">front page</a> or explore the
-          <a href="/documentation/">documentation</a>.
+          Head back to the <a href="/">front page</a> or explore the <a
+            href="/documentation/">documentation</a
+          >.
         </p>
         <p>
-          If you followed a broken link on flix.dev, feel free to report it on
-          <a href="https://github.com/flix/flix.dev/issues">GitHub</a>.
+          If you followed a broken link on flix.dev, feel free to report it on <a
+            href="https://github.com/flix/flix.dev/issues">GitHub</a
+          >.
         </p>
       </div>
     </div>

--- a/src/pages/faq.astro
+++ b/src/pages/faq.astro
@@ -432,9 +432,8 @@ import Question from "../components/FAQ/Question.astro";
       <div>
         <p class="card-text">
           The Flix syntax is <a href="/principles/">based on keywords</a> except when
-          there is a
-          <i>clearly established historical precedent</i> for using a symbol. For
-          example:
+          there is a <i>clearly established historical precedent</i> for using a
+          symbol. For example:
         </p>
 
         <ul>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -461,9 +461,10 @@ const vscodeSlides = [
           <div class="card-body">
             <div class="card-title"><h4>Monadic For-Yield</h4></div>
             <p class="card-text">
-              Flix supports a monadic <code>forM</code>-yield construct similar
-              to Scala's
-              <code>for</code>-comprehensions and Haskell's <code>do</code> notation.
+              Flix supports a monadic <code>forM</code>-yield construct similar to
+              Scala's <code>for</code>-comprehensions and Haskell's <code
+                >do</code
+              > notation.
               The <code>forM</code> construct is syntactic sugar for uses of <code
                 >point</code
               > and <code>flatMap</code> (which are provided by the <code
@@ -724,8 +725,7 @@ const vscodeSlides = [
         <p class="small text-muted">
           The above results can be reproduced by running the commands: <code
             >java -jar flix.jar Xperf --n 21</code
-          >
-          and <code>java -jar flix.jar Xperf --frontend --n 21</code>.
+          > and <code>java -jar flix.jar Xperf --frontend --n 21</code>.
         </p>
         <p>
           The Flix compiler achieves these results despite supporting costly


### PR DESCRIPTION
## Why

The compiler strips the whitespace at a line boundary when the break falls between a text node and an adjacent inline element. So a paragraph that wraps right before `<a>`, or right after `</code>`, renders the two words joined — the source looks correct, only the built HTML is wrong.

Five places did:

| Page | Renders as |
|---|---|
| `/404/` | "explore the**documentation**" |
| `/404/` | "report it on**GitHub**" |
| `/faq/` | "when there is a*clearly established historical precedent*" |
| `/` | "`java -jar flix.jar Xperf --n 21`**and**" |
| `/` | "similar to Scala's`for`-comprehensions" |

## What

Each paragraph is reflowed so the line break falls *inside* a tag rather than beside one — the `</code\n>` shape the rest of these files already use. No wording changes, and no rendering changes beyond the five missing spaces.

## Not touched

Three similar-looking joins are deliberate and were left alone: `VirtualThread</code>s` and `NullPointerException</code>s` put the plural outside the code element, `<code>if ... else </code>and` carries its space inside it, and the blog list separates each date from its author with a `px-1` span that supplies the gap.

## Testing

`npm run build`, then a sweep of all ten built pages for both directions of the pattern — `</code|a|b|i|span>` followed by a word character, and a word character followed by `<code|a|b|i>` — outside `<pre>` blocks. Zero remaining, and the five sentences were each read back from the built HTML with tags stripped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)