### PR TITLE
feat: show build and package management on the home page

### DIFF
--- a/src/components/PlainSnippet.astro
+++ b/src/components/PlainSnippet.astro
@@ -1,0 +1,18 @@
+---
+interface Props {
+  code: string;
+}
+
+const { code } = Astro.props;
+---
+
+{/* For blocks that are not Flix - terminal output, TOML - which CodeSnippet
+    would colour through the Flix grammar. Reuses that component's frame, so a
+    plain block and a highlighted one stack in a column without a seam.
+    overflow-x is set here because Astro's <Code> ships it inline on the <pre>
+    it renders, and a bare <pre> has nothing. */}
+<div class="code-snippet-frame">
+  <div class="code-snippet-code">
+    <pre style="overflow-x: auto">{code}</pre>
+  </div>
+</div>

--- a/src/lib/indexExamples.js
+++ b/src/lib/indexExamples.js
@@ -327,15 +327,35 @@ def testDivide01(): Unit \\ Assert =
 def testDivide02(): Unit \\ Assert =
     assertErr(divide(10, 0))`;
 
-// Terminal output rather than Flix, so the home page renders this one through a
-// plain <pre>: the CodeSnippet component only knows the Flix grammar and would
-// colour the PASS lines as if they were code.
+// Neither this nor the two that follow are Flix, so the home page renders them
+// with PlainSnippet: CodeSnippet only knows the Flix grammar and would colour
+// terminal output and TOML as if they were code.
 export const testOutput = `Running 2 tests...
 
    PASS  testDivide01 1.4ms
    PASS  testDivide02 0.3ms
 
 Passed: 2, Failed: 0. Skipped: 0. Elapsed: 2.1ms.`;
+
+export const manifestExample = `[package]
+name        = "hello-world"
+description = "A simple Flix package"
+version     = "0.1.0"
+license     = "Apache-2.0"
+
+[dependencies]
+"github:flix/museum" = "1.4.0"
+
+[mvn-dependencies]
+"org.apache.commons:commons-lang3" = "3.12.0"`;
+
+export const manifestOutput = `Found \`flix.toml'. Checking dependencies...
+Resolving Flix dependencies...
+  Downloading \`flix/museum.toml\` (v1.4.0)... OK.
+  Downloading \`flix/museum.fpkg\` (v1.4.0)... OK.
+Resolving Maven dependencies...
+  Adding \`org.apache.commons:commons-lang3' (3.12.0).
+Dependency resolution completed.`;
 
 export const datalogExample = `def reachable(g: List[(String, Int32, String)], minSpeed: Int32): List[(String, String)] =
     let facts = inject g into Road/3;

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -1,6 +1,7 @@
 ---
 import Layout from "../layouts/Layout.astro";
 import CodeSnippet from "../components/CodeSnippet.astro";
+import PlainSnippet from "../components/PlainSnippet.astro";
 import Carousel from "../components/Carousel.astro";
 import {
   httpExample,
@@ -25,6 +26,8 @@ import {
   terminationExample,
   testExample,
   testOutput,
+  manifestExample,
+  manifestOutput,
   datalogExample,
 } from "../lib/indexExamples.js";
 
@@ -554,6 +557,44 @@ const vscodeSlides = [
       <div class="col-md-6">
         <div class="card border-0">
           <div class="card-body">
+            <div class="card-title"><h4>Build and Package Management</h4></div>
+            <p class="card-text">
+              Flix has its own build tool and package manager. A project is
+              described by a single <code>flix.toml</code> manifest, shown on
+              the right, and <code>flix init</code> writes the first one for
+              you.
+            </p>
+            <p class="card-text">
+              Dependencies are Flix packages published on GitHub, or JARs
+              published on Maven &mdash; so pulling in the Java ecosystem is one
+              line in the manifest. Flix resolves both, transitively, and
+              downloads them on the next build.
+            </p>
+            <p class="card-text">
+              The commands <code>check</code>, <code>build</code>, <code
+                >run</code
+              >, <code>test</code>, <code>build-fatjar</code>, and <code
+                >release</code
+              > are built into the compiler itself, and each one works from the command
+              line, from the REPL, and from Visual Studio Code.
+            </p>
+          </div>
+        </div>
+      </div>
+      <div class="col-md-6">
+        <PlainSnippet code={manifestExample} />
+        <PlainSnippet code={manifestOutput} />
+      </div>
+    </div>
+
+    <div class="row mb-4">
+      <div class="col-md-6">
+        <CodeSnippet code={testExample} />
+        <PlainSnippet code={testOutput} />
+      </div>
+      <div class="col-md-6">
+        <div class="card border-0">
+          <div class="card-body">
             <div class="card-title"><h4>Built-in Test Framework</h4></div>
             <p class="card-text">
               Flix comes with a built-in test framework. A test is a function
@@ -571,17 +612,6 @@ const vscodeSlides = [
               them one at a time from the code lens above each test in Visual
               Studio Code.
             </p>
-          </div>
-        </div>
-      </div>
-      <div class="col-md-6">
-        <CodeSnippet code={testExample} />
-        {/* Terminal output, not Flix, so it bypasses CodeSnippet and reuses
-            only its frame. overflow-x is set here because Astro's <Code> ships
-            that inline on the <pre> it renders and a bare one has nothing. */}
-        <div class="code-snippet-frame">
-          <div class="code-snippet-code">
-            <pre style="overflow-x: auto">{testOutput}</pre>
           </div>
         </div>
       </div>


### PR DESCRIPTION
The tooling comparison table further down the page claims that `flix` is its own build tool and package manager, but nothing on the page showed a manifest or what dependency resolution looks like.

Adds a section between **Termination Checking** and **Built-in Test Framework**, text-left / code-right.

## What it shows

A `flix.toml` with package metadata, a Flix dependency from GitHub, and a JAR from Maven:

```toml
[package]
name        = "hello-world"
description = "A simple Flix package"
version     = "0.1.0"
license     = "Apache-2.0"

[dependencies]
"github:flix/museum" = "1.4.0"

[mvn-dependencies]
"org.apache.commons:commons-lang3" = "3.12.0"
```

and, stacked underneath it, what the next build prints:

```
Found `flix.toml'. Checking dependencies...
Resolving Flix dependencies...
  Downloading `flix/museum.toml` (v1.4.0)... OK.
  Downloading `flix/museum.fpkg` (v1.4.0)... OK.
Resolving Maven dependencies...
  Adding `org.apache.commons:commons-lang3' (3.12.0).
Dependency resolution completed.
```

Same two-block shape as the test framework section, so the pair reads as "the config, then what the tool does with it". The Maven coordinate is the same in both blocks so they agree.

## Layout

The test framework row flips to code-left, which keeps the three rows alternating:

| Section | |
|---|---|
| Termination Checking | code left / text right |
| Build and Package Management | text left / code right |
| Built-in Test Framework | code left / text right |

## PlainSnippet

This is the third block on the page that is not Flix — terminal output twice, TOML once — and `CodeSnippet` only knows the Flix grammar, so it would colour all three as if they were code. The inline markup is now `src/components/PlainSnippet.astro`, and the test output added in #214 uses it too. No rendered change to that block; I checked all three still come out verbatim.

`npm run check` and `npm run build` both pass, and the new card is clear of the #212 inline-whitespace trap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)