### PR TITLE
fix: update the TextMate grammar and colour pub with the other keywords

### DIFF
--- a/build-scripts/fetchGrammar.mjs
+++ b/build-scripts/fetchGrammar.mjs
@@ -2,7 +2,7 @@
 // up grammar changes, bump the SHA *and* delete the file below: the fetch is
 // skipped whenever it already exists, so on a working tree that has built once
 // the new SHA alone changes nothing.
-const COMMIT = 'befa883ecec4b0c84e436bdd176dec5475e584ab';
+const COMMIT = '1da5462a560b45eb7d8dbb25955fbf31606f90bd';
 const URL = `https://raw.githubusercontent.com/flix/textmate/${COMMIT}/syntaxes/flix.tmLanguage.json`;
 const DEST = 'src/grammars/flix.tmLanguage.json';
 

--- a/src/components/CodeSnippet.astro
+++ b/src/components/CodeSnippet.astro
@@ -10,13 +10,18 @@ const { code } = Astro.props;
 import flixGrammar from "../grammars/flix.tmLanguage.json";
 
 // Light+ colors `keyword`/`storage` blue but `keyword.control` magenta;
-// unify them so all Flix keywords share the magenta.
+// unify them so all Flix keywords share the magenta. `storage.modifier` is
+// named explicitly because the most specific selector wins rather than the last
+// one, so a bare `storage` here loses to Light+'s own `storage.modifier` rule.
 const theme = {
   ...lightPlus,
   name: "light-plus-flix",
   tokenColors: [
     ...(lightPlus.tokenColors ?? []),
-    { scope: ["keyword", "storage"], settings: { foreground: "#AF00DB" } },
+    {
+      scope: ["keyword", "storage", "storage.modifier"],
+      settings: { foreground: "#AF00DB" },
+    },
   ],
 };
 ---


### PR DESCRIPTION
Bumps the pinned [flix/textmate](https://github.com/flix/textmate) commit from `befa883` to `1da5462`, and fixes a theme override that kept `pub` blue.

## Grammar

Upstream changes picked up by the bump:

- function names are highlighted: `foo(...)` gets `entity.name.function`, `List.map` gets `support.function`
- the type rule widens from the 11 primitives to every capitalised identifier
- `pub` moves from `storage.type.modifier.flix` to `storage.modifier.flix`
- `dbg`, `resume`, `typematch`, `law`, `without`, `opaque`, `handler`, `xvar`, `branch`, `jumpto`, and `lawful` are dropped

## Why `pub` stayed blue

The scope rename on its own changed nothing on the site. `CodeSnippet.astro` appends a rule for a bare `storage` to make every Flix keyword magenta, but TextMate resolves a token to the *most specific* matching selector rather than the last one written — and Light+ ships its own `storage.modifier` rule in blue. A bare `storage` loses to it, just as it previously lost to `storage.type`.

Naming `storage.modifier` explicitly ties on specificity, so the override wins on order.

`pub def foo(): Int32 = 42` rendered through the site's theme:

| | `pub` | `def` | `foo` | `Int32` |
|---|---|---|---|---|
| before | `#0000FF` | `#AF00DB` | — | `#267F99` |
| after | `#AF00DB` | `#AF00DB` | `#795E26` | `#267F99` |

🤖 Generated with [Claude Code](https://claude.com/claude-code)