### PR TITLE
feat: support dark mode

### DIFF
--- a/src/components/CodeSnippet.astro
+++ b/src/components/CodeSnippet.astro
@@ -1,6 +1,5 @@
 ---
 import { Code } from "astro:components";
-import type { ThemeRegistration } from "shiki";
 import lightPlus from "@shikijs/themes/light-plus";
 import darkPlus from "@shikijs/themes/dark-plus";
 interface Props {
@@ -17,13 +16,14 @@ import flixGrammar from "../grammars/flix.tmLanguage.json";
 // last one, so a bare `storage` here loses to the theme's own
 // `storage.modifier` rule. The two magentas are each theme's own, not one value
 // used twice: #AF00DB is legible on white and would be far too dark on #1a1d20.
-const unifyKeywords = (
-  base: ThemeRegistration,
-  name: string,
-  foreground: string,
-): ThemeRegistration => ({
+// The name is derived rather than passed so it cannot drift from the theme it
+// describes; it reaches the markup as a class, so it wants to stay truthful.
+// Typed off lightPlus because `shiki` itself is not a dependency here -- it
+// resolves only through astro -- and @shikijs/themes already declares its
+// exports as ThemeRegistration.
+const unifyKeywords = (base: typeof lightPlus, foreground: string) => ({
   ...base,
-  name,
+  name: `${base.name}-flix`,
   tokenColors: [
     ...(base.tokenColors ?? []),
     {
@@ -38,8 +38,8 @@ const unifyKeywords = (
 // switches between. Keeping light as the default means the markup renders
 // correctly for the light theme with no CSS applied at all.
 const themes = {
-  light: unifyKeywords(lightPlus, "light-plus-flix", "#AF00DB"),
-  dark: unifyKeywords(darkPlus, "dark-plus-flix", "#C586C0"),
+  light: unifyKeywords(lightPlus, "#AF00DB"),
+  dark: unifyKeywords(darkPlus, "#C586C0"),
 };
 ---
 

--- a/src/components/CodeSnippet.astro
+++ b/src/components/CodeSnippet.astro
@@ -1,6 +1,8 @@
 ---
 import { Code } from "astro:components";
+import type { ThemeRegistration } from "shiki";
 import lightPlus from "@shikijs/themes/light-plus";
+import darkPlus from "@shikijs/themes/dark-plus";
 interface Props {
   code: string;
 }
@@ -9,25 +11,45 @@ const { code } = Astro.props;
 
 import flixGrammar from "../grammars/flix.tmLanguage.json";
 
-// Light+ colors `keyword`/`storage` blue but `keyword.control` magenta;
-// unify them so all Flix keywords share the magenta. `storage.modifier` is
-// named explicitly because the most specific selector wins rather than the last
-// one, so a bare `storage` here loses to Light+'s own `storage.modifier` rule.
-const theme = {
-  ...lightPlus,
-  name: "light-plus-flix",
+// Both Plus themes color `keyword`/`storage` blue but `keyword.control`
+// magenta; unify them so all Flix keywords share the magenta. `storage.modifier`
+// is named explicitly because the most specific selector wins rather than the
+// last one, so a bare `storage` here loses to the theme's own
+// `storage.modifier` rule. The two magentas are each theme's own, not one value
+// used twice: #AF00DB is legible on white and would be far too dark on #1a1d20.
+const unifyKeywords = (
+  base: ThemeRegistration,
+  name: string,
+  foreground: string,
+): ThemeRegistration => ({
+  ...base,
+  name,
   tokenColors: [
-    ...(lightPlus.tokenColors ?? []),
+    ...(base.tokenColors ?? []),
     {
       scope: ["keyword", "storage", "storage.modifier"],
-      settings: { foreground: "#AF00DB" },
+      settings: { foreground },
     },
   ],
+});
+
+// Shiki emits both themes at once: the light colors land in `color` and the
+// dark ones in a --shiki-dark custom property beside them, which global.css
+// switches between. Keeping light as the default means the markup renders
+// correctly for the light theme with no CSS applied at all.
+const themes = {
+  light: unifyKeywords(lightPlus, "light-plus-flix", "#AF00DB"),
+  dark: unifyKeywords(darkPlus, "dark-plus-flix", "#C586C0"),
 };
 ---
 
 <div class="code-snippet-frame">
   <div class="code-snippet-code">
-    <Code code={code} theme={theme} lang={flixGrammar} />
+    <Code
+      code={code}
+      themes={themes}
+      defaultColor="light"
+      lang={flixGrammar}
+    />
   </div>
 </div>

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -176,8 +176,9 @@ import '../styles/global.css';
               alt="Fork me on GitHub">
         </a>
         {/* data-bs-theme has to sit on the .navbar itself: Bootstrap keys the
-            light-on-dark link and toggler colours off .navbar[data-bs-theme="dark"]. */}
-        <nav class="navbar bg-dark navbar-expand-lg menu shadow-sm mb-4" data-bs-theme="dark" aria-label="Main">
+            light-on-dark link and toggler colours off .navbar[data-bs-theme="dark"].
+            It says nothing about the background, which .menu paints. */}
+        <nav class="navbar navbar-expand-lg menu shadow-sm mb-4" data-bs-theme="dark" aria-label="Main">
           <div class="container-fluid">
             <a class="navbar-brand d-flex align-items-center gap-2" href="/">
               <FlixMark size={24} />

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -95,6 +95,7 @@ const footerGroups = [
 ];
 
 import FlixMark from '../components/FlixMark.astro';
+import { Icon } from 'astro-icon/components';
 import '../styles/global.css';
 ---
 <!doctype html>
@@ -102,6 +103,36 @@ import '../styles/global.css';
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
+
+    {/* First thing in the head, and is:inline so it stays here rather than
+        being bundled into a deferred module: it has to have set the attribute
+        before the first paint, and a deferred script runs after it, which is
+        the flash of the wrong theme this exists to prevent.
+
+        Bootstrap 5.3 keys its whole dark palette off data-bs-theme and ships no
+        prefers-color-scheme rules of its own, so the media query cannot be left
+        to CSS and is read here. localStorage is wrapped because it throws
+        outright, rather than returning null, when site data is blocked. */}
+    <script is:inline>
+      (() => {
+        let stored = null;
+        try {
+          stored = localStorage.getItem("theme");
+        } catch {}
+        const theme =
+          stored === "light" || stored === "dark"
+            ? stored
+            : matchMedia("(prefers-color-scheme: dark)").matches
+              ? "dark"
+              : "light";
+        document.documentElement.setAttribute("data-bs-theme", theme);
+      })();
+    </script>
+
+    {/* Covers the gap before the stylesheet applies, and tells the browser to
+        draw the scrollbar and any form controls to match. */}
+    <meta name="color-scheme" content="light dark" />
+
     <title>{title}</title>
     <meta name="description" content={description} />
     {
@@ -152,6 +183,20 @@ import '../styles/global.css';
               <FlixMark size={24} />
               Flix
             </a>
+            {/* Deliberately outside the collapse: the theme is worth changing
+                on a phone too, and inside it the button would only be reachable
+                by first opening the menu. order-lg-last sends it to the far end
+                once the nav expands, since in source order it has to precede
+                the collapse to sit left of the hamburger below that. */}
+            <button
+              class="btn btn-sm theme-toggle ms-auto ms-lg-0 me-2 me-lg-0 order-lg-last d-flex align-items-center"
+              type="button"
+              aria-label="Switch between the light and dark theme"
+              title="Switch between the light and dark theme"
+            >
+              <Icon name="mdi:weather-night" class="theme-toggle-to-dark" size={18} />
+              <Icon name="mdi:weather-sunny" class="theme-toggle-to-light" size={18} />
+            </button>
             <button
               class="navbar-toggler"
               type="button"
@@ -252,6 +297,36 @@ import '../styles/global.css';
       // frontmatter alongside the stylesheet import.
       import "bootstrap/js/dist/collapse";
       import "bootstrap/js/dist/carousel";
+
+      // The head script already picked the theme; this only handles changing it
+      // afterwards, so it can wait for the bundle. Writing to localStorage is
+      // what turns a choice into a preference: from then on the branch above
+      // reads it and stops consulting the OS.
+      const root = document.documentElement;
+
+      document.querySelector(".theme-toggle")?.addEventListener("click", () => {
+        const next =
+          root.getAttribute("data-bs-theme") === "dark" ? "light" : "dark";
+        root.setAttribute("data-bs-theme", next);
+        try {
+          localStorage.setItem("theme", next);
+        } catch {}
+      });
+
+      // Follow the OS live, but only for visitors who have never used the
+      // toggle -- once they have, their choice outranks it.
+      matchMedia("(prefers-color-scheme: dark)").addEventListener(
+        "change",
+        (event) => {
+          let stored = null;
+          try {
+            stored = localStorage.getItem("theme");
+          } catch {}
+          if (stored !== "light" && stored !== "dark") {
+            root.setAttribute("data-bs-theme", event.matches ? "dark" : "light");
+          }
+        },
+      );
     </script>
   </body>
 </html>

--- a/src/pages/documentation.astro
+++ b/src/pages/documentation.astro
@@ -63,7 +63,7 @@ const smallLinks = [
               Programming Flix (doc.flix.dev)
             </a>
           </div>
-          <p class="card-text text-dark text-center">
+          <p class="card-text text-body text-center">
             A detailed introduction to the Flix Programming Language.
           </p>
         </div>
@@ -80,7 +80,7 @@ const smallLinks = [
               Standard Library (api.flix.dev)
             </a>
           </div>
-          <p class="card-text text-dark text-center">
+          <p class="card-text text-body text-center">
             A Javadoc-style description of the Flix Standard Library.
           </p>
         </div>
@@ -99,7 +99,7 @@ const smallLinks = [
           <div class="col-lg-2">
             <a href={link}>
               <div class="card h-100 card-body">
-                <div class="text-center m-4 text-black-50 card-subtitle">
+                <div class="text-center m-4 text-body-secondary card-subtitle">
                   <Icon name={icon} size={SMALL_ICON_SIZE} />
                 </div>
                 <div class="text-center link-primary card-title">{text}</div>

--- a/src/pages/get-started.astro
+++ b/src/pages/get-started.astro
@@ -77,7 +77,7 @@ const installs = [
       <div class="col">
         <div class="card ms-5 me-5">
           <img
-            class="card-img-top"
+            class="card-img-top plate"
             src="/gif/install.png"
             alt="Installing the Flix extension from the Visual Studio Code Extensions view"
           />

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -720,7 +720,7 @@ const vscodeSlides = [
         <div class="card">
           <img
             src="/images/standardLibrary.png"
-            class="card-img"
+            class="card-img plate"
             alt="Standard Library"
             loading="lazy"
           />
@@ -757,7 +757,7 @@ const vscodeSlides = [
       <div class="col-md-6">
         <img
           src="/images/speedupWithPar.png"
-          class="img-fluid"
+          class="img-fluid plate p-3"
           alt="Parallel Speedup"
           loading="lazy"
         />
@@ -1133,7 +1133,7 @@ const vscodeSlides = [
 
     <div class="row mb-4">
       <div class="col-md">
-        <div class="card border-0 p-3">
+        <div class="card border-0 p-3 plate">
           <img
             src="/logo/dff.png"
             class="card-img"
@@ -1143,7 +1143,7 @@ const vscodeSlides = [
         </div>
       </div>
       <div class="col-md">
-        <div class="card border-0 p-3">
+        <div class="card border-0 p-3 plate">
           <img
             src="/logo/dara-academy.png"
             class="card-img"
@@ -1153,7 +1153,7 @@ const vscodeSlides = [
         </div>
       </div>
       <div class="col-md">
-        <div class="card border-0 p-3">
+        <div class="card border-0 p-3 plate">
           <img
             src="/logo/direc.png"
             class="card-img"
@@ -1163,7 +1163,7 @@ const vscodeSlides = [
         </div>
       </div>
       <div class="col-md">
-        <div class="card border-0 p-3">
+        <div class="card border-0 p-3 plate">
           <img
             src="/logo/amazon-science.png"
             class="card-img"
@@ -1173,7 +1173,7 @@ const vscodeSlides = [
         </div>
       </div>
       <div class="col-md">
-        <div class="card border-0 p-3">
+        <div class="card border-0 p-3 plate">
           <img src="/logo/stibo.png" class="card-img" alt="StiboFonden" loading="lazy" />
         </div>
       </div>
@@ -1189,7 +1189,7 @@ const vscodeSlides = [
 
     <div class="row mb-4">
       <div class="col-md-3">
-        <div class="card border-0 p-3">
+        <div class="card border-0 p-3 plate">
           <img
             src="/logo/aarhusu.png"
             class="card-img"
@@ -1199,7 +1199,7 @@ const vscodeSlides = [
         </div>
       </div>
       <div class="col-md-4">
-        <div class="card border-0 p-3">
+        <div class="card border-0 p-3 plate">
           <img
             src="/logo/uwaterloo.png"
             class="card-img"
@@ -1209,7 +1209,7 @@ const vscodeSlides = [
         </div>
       </div>
       <div class="col-md-3">
-        <div class="card border-0 p-3">
+        <div class="card border-0 p-3 plate">
           <img
             src="/logo/tubingen.png"
             class="card-img"

--- a/src/pages/vscode.astro
+++ b/src/pages/vscode.astro
@@ -71,7 +71,7 @@ const features = [
               <h4 class="card-title">{f.title}</h4>
               <p class="card-text mb-0" set:html={f.desc}></p>
             </div>
-            <img class="card-img-bottom" src={f.img} alt={f.alt} loading={i < 2 ? "eager" : "lazy"} />
+            <img class="card-img-bottom plate" src={f.img} alt={f.alt} loading={i < 2 ? "eager" : "lazy"} />
           </div>
         </div>
       ))}

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -20,6 +20,13 @@
 :root {
     --flix-red: #cf4647;
 
+    /* The site is made of three surfaces and nothing else: the page behind the
+       card, the card itself, and the code blocks on it. Naming them is what
+       lets the dark theme below swap the lot in one place. */
+    --flix-bg-page: #efefef;
+    --flix-bg-card: #ffffff;
+    --flix-bg-code: #f7f7f7;
+
     --bs-primary: #a63839;
     --bs-primary-rgb: 166, 56, 57;
     --bs-link-color-rgb: 166, 56, 57;
@@ -34,10 +41,40 @@
     --bs-success-rgb: 0, 137, 56;
 }
 
+/* Bootstrap 5.3's dark palette is driven entirely by this attribute: the
+   precompiled stylesheet the layout imports contains no prefers-color-scheme
+   at all, which is why the media query is read by the inline script in
+   Layout.astro and written here instead. That block also sets color-scheme
+   and --bs-body-bg: #212529, so the card matches what every Bootstrap
+   component is already drawing itself against.
+
+   Scoped to :root rather than bare [data-bs-theme="dark"] because the navbar
+   carries the same attribute permanently -- an unscoped rule would re-declare
+   the whole palette inside it in light mode too.
+
+   The contrast argument in :root runs backwards here. #a63839 and #008938 were
+   darkened to clear 4.5:1 on white and both fall to 3.4:1 on the dark card, so
+   these are the same two colours taken the other way: 6.4:1 for the red, which
+   is what the light one measures, and 5.5:1 for the green, still fully
+   saturated at hue 145 with only its lightness moved. */
+:root[data-bs-theme="dark"] {
+    --flix-bg-page: #16181b;
+    --flix-bg-card: #212529;
+    --flix-bg-code: #1a1d20;
+
+    --bs-primary: #ef8b8c;
+    --bs-primary-rgb: 239, 139, 140;
+    --bs-link-color-rgb: 239, 139, 140;
+    --bs-link-hover-color-rgb: 244, 166, 167;
+
+    --bs-success: #00b34a;
+    --bs-success-rgb: 0, 179, 74;
+}
+
 body {
     font-family: 'Open Sans', sans-serif;
     overflow-y: scroll;
-    background-color: #efefef;
+    background-color: var(--flix-bg-page);
 }
 
 /* Matching Bootstrap's own `h1, .h1` pairing keeps the utility classes in step
@@ -76,6 +113,15 @@ h4, .h4 {
     view-transition-name: navbar;
 }
 
+/* .bg-dark resolves to #212529, which in dark mode is also the card's colour --
+   the bar would dissolve into the page it sits on. Lifting it one step keeps it
+   reading as a bar. Done by moving the token .bg-dark reads rather than by
+   restating the background, since Bootstrap ships that declaration !important
+   and overriding it directly would mean matching that. */
+:root[data-bs-theme="dark"] .menu {
+    --bs-dark-rgb: 43, 48, 53;
+}
+
 /* Bootstrap 5 adds an xxl breakpoint that widens .container to 1320px. Hold
    the page at the width it has always had; line lengths here are tuned for it. */
 @media (min-width: 1400px) {
@@ -85,7 +131,7 @@ h4, .h4 {
 }
 
 .page {
-    background-color: white;
+    background-color: var(--flix-bg-card);
     min-height: 95vh;
     display: flex;
     flex-direction: column;
@@ -112,7 +158,20 @@ h4, .h4 {
    bottom padding lives on the <pre> for the same reason. */
 .code-snippet-code {
     padding: 0.9em 1.6em 0;
-    background-color: #f7f7f7;
+    background-color: var(--flix-bg-code);
+}
+
+/* Shiki's dual-theme output leaves the light colour in `color` and parks the
+   dark one in a --shiki-dark custom property on the same element, so switching
+   themes is a matter of choosing which of the two to read. !important because
+   the colours arrive as inline styles on every token. The background is not
+   included: .code-snippet-code owns it, and the <pre> is transparent below.
+
+   .astro-code, not Shiki's own .shiki -- Astro renames the class on the way
+   out, and the documented one matches nothing here. */
+:root[data-bs-theme="dark"] .code-snippet-code .astro-code,
+:root[data-bs-theme="dark"] .code-snippet-code .astro-code span {
+    color: var(--shiki-dark) !important;
 }
 
 .code-snippet-code pre,
@@ -149,6 +208,61 @@ h4, .h4 {
     .navbar-nav .nav-link.active {
         border-bottom-color: var(--flix-red);
     }
+}
+
+/* Everything pictorial on the site assumes a light ground: the editor captures
+   were taken in a light theme, the matplotlib figures label their axes in
+   black, and the sponsor logos are dark ink on transparency. None of it can be
+   recoloured -- other organisations' marks least of all -- so each keeps a
+   white ground of its own in both themes. Unconditional, because in light mode
+   it is already the colour of the card underneath and changes nothing there.
+
+   Background only, deliberately: the elements this lands on already carry the
+   right corners from Bootstrap -- .card-img-bottom rounds its bottom two and
+   squares the top two against the card body above it -- and global.css loads
+   after Bootstrap, so a radius here would overwrite that with all four. */
+.plate {
+    background-color: #ffffff;
+}
+
+/* The toggle sits among the nav links and should read as one of them rather
+   than as a control, so it carries no box. Stating the three properties here
+   rather than reaching for a .btn-* variant is what removes it: the variants
+   are what supply the border in the first place, and without one the
+   --bs-btn-* tokens .btn refers to are simply undefined. The colours are the
+   navbar's own, so the icon tracks the links either side of it exactly. */
+.theme-toggle {
+    background-color: transparent;
+    border: 0;
+    color: var(--bs-navbar-color);
+}
+
+.theme-toggle:hover {
+    color: var(--bs-navbar-hover-color);
+}
+
+/* Restored explicitly for the same reason: dropping the variant dropped the
+   focus ring with it, and the button has to stay reachable by keyboard. */
+.theme-toggle:focus-visible {
+    color: var(--bs-navbar-active-color);
+    outline: 2px solid var(--bs-navbar-active-color);
+    outline-offset: 2px;
+}
+
+/* Only one of the two icons in the toggle is ever shown, and which one cannot
+   be decided at build time -- the theme is not known until the inline script
+   runs. Both ship, and the attribute picks. :root again because the button sits
+   inside the permanently dark navbar. */
+.theme-toggle-to-light {
+    display: none;
+}
+
+:root[data-bs-theme="dark"] .theme-toggle-to-light {
+    display: inline-block;
+}
+
+:root[data-bs-theme="dark"] .theme-toggle-to-dark {
+    display: none;
 }
 
 .card-title {

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -20,11 +20,14 @@
 :root {
     --flix-red: #cf4647;
 
-    /* The site is made of three surfaces and nothing else: the page behind the
-       card, the card itself, and the code blocks on it. Naming them is what
-       lets the dark theme below swap the lot in one place. */
+    /* The site is made of four surfaces: the page behind the card, the card,
+       the navbar, and the code blocks. Three are named here so the dark theme
+       below can swap them in one place. The fourth is not: the card is
+       Bootstrap's --bs-body-bg, which is what .card, .list-group and .dropdown
+       all already resolve to, so giving it a name of its own would only be a
+       second value to keep in step with it by hand. */
     --flix-bg-page: #efefef;
-    --flix-bg-card: #ffffff;
+    --flix-bg-navbar: #212529;
     --flix-bg-code: #f7f7f7;
 
     --bs-primary: #a63839;
@@ -44,9 +47,8 @@
 /* Bootstrap 5.3's dark palette is driven entirely by this attribute: the
    precompiled stylesheet the layout imports contains no prefers-color-scheme
    at all, which is why the media query is read by the inline script in
-   Layout.astro and written here instead. That block also sets color-scheme
-   and --bs-body-bg: #212529, so the card matches what every Bootstrap
-   component is already drawing itself against.
+   Layout.astro and written here instead. That block also sets color-scheme,
+   and turns --bs-body-bg to #212529, which is where the card gets its colour.
 
    Scoped to :root rather than bare [data-bs-theme="dark"] because the navbar
    carries the same attribute permanently -- an unscoped rule would re-declare
@@ -59,7 +61,7 @@
    saturated at hue 145 with only its lightness moved. */
 :root[data-bs-theme="dark"] {
     --flix-bg-page: #16181b;
-    --flix-bg-card: #212529;
+    --flix-bg-navbar: #2b3035;
     --flix-bg-code: #1a1d20;
 
     --bs-primary: #ef8b8c;
@@ -111,15 +113,14 @@ h4, .h4 {
     /* The navbar is identical on every page; naming it lifts it out of the
        root cross-fade so it holds still during transitions. */
     view-transition-name: navbar;
-}
 
-/* .bg-dark resolves to #212529, which in dark mode is also the card's colour --
-   the bar would dissolve into the page it sits on. Lifting it one step keeps it
-   reading as a bar. Done by moving the token .bg-dark reads rather than by
-   restating the background, since Bootstrap ships that declaration !important
-   and overriding it directly would mean matching that. */
-:root[data-bs-theme="dark"] .menu {
-    --bs-dark-rgb: 43, 48, 53;
+    /* Its own surface rather than Bootstrap's .bg-dark, which resolves to
+       #212529 -- in dark mode the colour of the card, so the bar would dissolve
+       into the page it sits on. The dark value is one step up from the card
+       instead, and the light one is what .bg-dark was already painting, so the
+       light navbar is unchanged. A token also keeps this out of a fight with
+       .bg-dark's !important. */
+    background-color: var(--flix-bg-navbar);
 }
 
 /* Bootstrap 5 adds an xxl breakpoint that widens .container to 1320px. Hold
@@ -131,7 +132,7 @@ h4, .h4 {
 }
 
 .page {
-    background-color: var(--flix-bg-card);
+    background-color: var(--bs-body-bg);
     min-height: 95vh;
     display: flex;
     flex-direction: column;
@@ -226,23 +227,22 @@ h4, .h4 {
 }
 
 /* The toggle sits among the nav links and should read as one of them rather
-   than as a control, so it carries no box. Stating the three properties here
-   rather than reaching for a .btn-* variant is what removes it: the variants
-   are what supply the border in the first place, and without one the
-   --bs-btn-* tokens .btn refers to are simply undefined. The colours are the
-   navbar's own, so the icon tracks the links either side of it exactly. */
+   than as a control, so it carries no box. No .btn-* variant, because the
+   variants are what supply the border and the filled background; base .btn on
+   its own is already transparent. What a variant would also have set are the
+   two colour tokens below, which .btn and .btn:hover read -- pointing them at
+   the navbar's own colours is what makes the icon track the links either side
+   of it. The border is zeroed rather than left transparent so it stops taking
+   up a pixel on each side. */
 .theme-toggle {
-    background-color: transparent;
+    --bs-btn-color: var(--bs-navbar-color);
+    --bs-btn-hover-color: var(--bs-navbar-hover-color);
     border: 0;
-    color: var(--bs-navbar-color);
 }
 
-.theme-toggle:hover {
-    color: var(--bs-navbar-hover-color);
-}
-
-/* Restored explicitly for the same reason: dropping the variant dropped the
-   focus ring with it, and the button has to stay reachable by keyboard. */
+/* An outline rather than the --bs-btn-focus-shadow-rgb ring base .btn leaves
+   unset: a soft glow is easy to lose against the navbar, and this has to stay
+   obvious enough to keyboard-navigate by. */
 .theme-toggle:focus-visible {
     color: var(--bs-navbar-active-color);
     outline: 2px solid var(--bs-navbar-active-color);
@@ -251,16 +251,13 @@ h4, .h4 {
 
 /* Only one of the two icons in the toggle is ever shown, and which one cannot
    be decided at build time -- the theme is not known until the inline script
-   runs. Both ship, and the attribute picks. :root again because the button sits
-   inside the permanently dark navbar. */
-.theme-toggle-to-light {
-    display: none;
-}
-
-:root[data-bs-theme="dark"] .theme-toggle-to-light {
-    display: inline-block;
-}
-
+   runs. Both ship, and the attribute picks. Hiding is all that is stated: the
+   button is a flex container, so the icon left standing is a flex item and is
+   blockified whatever its display says. :not() rather than a plain rule and a
+   restore, so that with the script blocked and no attribute set at all the
+   moon still shows against the light theme the page falls back to. :root on
+   both because the button sits inside the permanently dark navbar. */
+:root:not([data-bs-theme="dark"]) .theme-toggle-to-light,
 :root[data-bs-theme="dark"] .theme-toggle-to-dark {
     display: none;
 }


### PR DESCRIPTION
Adds dark mode across all ten pages. The site follows the OS setting on first visit and offers a toggle in the navbar; once used, the choice persists and outranks the OS from then on.

## How it works

Bootstrap 5.3's dark palette is driven entirely by `data-bs-theme` — the precompiled stylesheet we import contains no `prefers-color-scheme` rules at all, so a pure-CSS approach would have needed a Sass build step and would have ruled out a manual toggle. Instead an `is:inline` script at the top of `<head>` reads `localStorage`, falls back to `matchMedia`, and stamps the attribute on `<html>` before the first paint, so there is no flash of the wrong theme.

## Colours

The three surfaces the site is made of — the page, the card, and the code blocks — are now named as custom properties, which is what lets the dark theme swap all of them in one place.

The brand red and green are redefined alongside them. Both were darkened specifically to clear 4.5:1 against white, as the comments in `global.css` record, and both fall to 3.4:1 on a dark card. The dark theme takes the same two colours the other way instead:

| | light | | dark | |
|---|---|---|---|---|
| link / `.text-primary` | `#a63839` | 6.47:1 | `#ef8b8c` | 6.42:1 |
| `.text-success` | `#008938` | 4.53:1 | `#00b34a` | 5.54:1 |

The green keeps hue 145 at full saturation exactly as the light one does; only its lightness moves. Ratios were measured rather than estimated, against a checker validated on the existing values the comments already state.

The navbar needs its own surface in dark mode: `.bg-dark` resolves to `#212529`, which is also Bootstrap's dark `--bs-body-bg` and therefore the card, so the bar would have dissolved into the page behind it. Lifting it one step leaves inactive nav links at 5.20:1, down from 5.67:1 and still clear of 4.5.

## Code snippets

Snippets now ship both Plus themes at once through Shiki's dual-theme output. The existing correction that unifies Flix keywords on `keyword.control`'s magenta is applied to each theme in its own magenta — Light+'s `#AF00DB` is illegible on a dark background. Note that Astro renames Shiki's class to `astro-code` on the way out, so the theme switch keys off that rather than the documented `.shiki`.

## Images

Screenshots, figures, and sponsor logos keep a white ground in both themes, via a single `.plate` class. Nearly every image on the site carries an alpha channel and the sponsor marks are dark ink on transparency, so on a dark page they would otherwise have gone dark-on-dark. Recolouring them was not an option — several are other organisations' marks. In light mode the plate is the colour of the card underneath, so it changes nothing there.

## Verification

`astro check` and `astro build` are both clean. Visually checked across all ten pages in both themes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
