### PR TITLE
fix: stop the navbar shifting when the active link goes bold

### DIFF
--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -213,7 +213,7 @@ import '../styles/global.css';
               <ul class="navbar-nav me-lg-auto">
                 {navLinks.map(({ href, label }) => (
                   <li class="nav-item ps-1 pe-1">
-                    <a class={`nav-link${currentPath === href ? " active fw-bold" : ""}`} href={href}>
+                    <a class={`nav-link${currentPath === href ? " active fw-bold" : ""}`} href={href} data-label={label}>
                       {label}
                     </a>
                   </li>

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -209,6 +209,22 @@ h4, .h4 {
     .navbar-nav .nav-link.active {
         border-bottom-color: var(--flix-red);
     }
+
+    /* The same problem along the other axis: 700 is wider than 400, so bolding
+       the active link would push every item after it to the right. Each link
+       carries an invisible bold copy of its own label, which sets the width for
+       both states and leaves the measuring to the browser rather than to nine
+       hard-coded numbers that would drift the next time a label is renamed.
+       visibility is what keeps that copy out of the accessibility tree; a zero
+       height alone hides it from the eye but not from a screen reader. */
+    .navbar-nav .nav-link::after {
+        content: attr(data-label);
+        display: block;
+        font-weight: 700;
+        height: 0;
+        overflow: hidden;
+        visibility: hidden;
+    }
 }
 
 /* Everything pictorial on the site assumes a light ground: the editor captures


### PR DESCRIPTION
The active nav link carries `fw-bold`, and Open Sans 700 glyphs are wider than 400, so the current page's `<li>` grows a few pixels and every item after it slides right.

The fix mirrors the transparent `border-bottom` one rule above it, which already prevents the same shift on the vertical axis: reserve the widest state on every item. Each link now renders an invisible bold copy of its own label via `::after`, so its width is the bold width in both states.

- `visibility: hidden` is the load-bearing part — it keeps the duplicated text out of the accessibility tree, so the link is still announced once. `height: 0` alone would hide it from the eye but not from a screen reader.
- The pseudo-element is not in the DOM, so the served HTML, copy/paste, find-in-page, and crawlers all see each label exactly once.
- Scoped to the existing `@media (min-width: 992px)` block: in the collapsed menu the links stack full-width and there is nothing to shift.

Letting the browser measure it avoids hard-coding nine per-item widths, which would drift silently the next time a label is renamed or one is added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)