### PR TITLE
refactor: move the theme toggle into a file of its own

### DIFF
--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -299,35 +299,10 @@ import '../styles/global.css';
       import "bootstrap/js/dist/collapse";
       import "bootstrap/js/dist/carousel";
 
-      // The head script already picked the theme; this only handles changing it
-      // afterwards, so it can wait for the bundle. Writing to localStorage is
-      // what turns a choice into a preference: from then on the branch above
-      // reads it and stops consulting the OS.
-      const root = document.documentElement;
-
-      document.querySelector(".theme-toggle")?.addEventListener("click", () => {
-        const next =
-          root.getAttribute("data-bs-theme") === "dark" ? "light" : "dark";
-        root.setAttribute("data-bs-theme", next);
-        try {
-          localStorage.setItem("theme", next);
-        } catch {}
-      });
-
-      // Follow the OS live, but only for visitors who have never used the
-      // toggle -- once they have, their choice outranks it.
-      matchMedia("(prefers-color-scheme: dark)").addEventListener(
-        "change",
-        (event) => {
-          let stored = null;
-          try {
-            stored = localStorage.getItem("theme");
-          } catch {}
-          if (stored !== "light" && stored !== "dark") {
-            root.setAttribute("data-bs-theme", event.matches ? "dark" : "light");
-          }
-        },
-      );
+      // In a file of its own so it is typechecked as one -- a script block here
+      // is not. The theme's other half cannot join it: that one has to be
+      // is:inline in the head, and is up there.
+      import "../scripts/theme-toggle.ts";
     </script>
   </body>
 </html>

--- a/src/scripts/theme-toggle.ts
+++ b/src/scripts/theme-toggle.ts
@@ -1,0 +1,29 @@
+// Changing the theme after the page has loaded. Picking it in the first place
+// belongs to the is:inline script in Layout.astro's <head>, which has to run
+// before the first paint; this half has nothing to do until someone clicks, so
+// it rides along in the bundle instead.
+const root = document.documentElement;
+
+// Writing to localStorage is what turns a choice into a preference: from then
+// on the head script reads it and stops consulting the OS.
+document.querySelector(".theme-toggle")?.addEventListener("click", () => {
+  const next = root.getAttribute("data-bs-theme") === "dark" ? "light" : "dark";
+  root.setAttribute("data-bs-theme", next);
+  try {
+    localStorage.setItem("theme", next);
+  } catch {}
+});
+
+// Follow the OS live, but only for visitors who have never used the toggle --
+// once they have, their choice outranks it. localStorage is wrapped for the
+// same reason it is in the head script: blocked site data makes it throw rather
+// than return null.
+matchMedia("(prefers-color-scheme: dark)").addEventListener("change", (event) => {
+  let stored = null;
+  try {
+    stored = localStorage.getItem("theme");
+  } catch {}
+  if (stored !== "light" && stored !== "dark") {
+    root.setAttribute("data-bs-theme", event.matches ? "dark" : "light");
+  }
+});


### PR DESCRIPTION
Moves the theme toggle out of the `<script>` block in `Layout.astro` and into `src/scripts/theme-toggle.ts`.

The motivation is typechecking: a script block in an `.astro` file is not checked, a `.ts` file is. `astro check` goes from 25 files to 26 and passes clean. The block left behind becomes a third import alongside Bootstrap's two, which reads as a list of what runs on the page rather than as a place where some of it happens to live.

## Nothing changes in the output

Astro was already bundling this block into its own file, so this is a source move only. The emitted bundle is byte-identical, down to the content hash:

| | before | after |
|---|---|---|
| bundle | `Layout.astro_astro_type_script_index_0_lang.DHQd3bgp.js` | same hash |
| size | 23,047 bytes | 23,047 bytes |

The built HTML carries the same three script tags, and the inline head script is untouched.

## Why the other half stays in the layout

The theme is picked by an `is:inline` script in `<head>` that has to run before the first paint. That one cannot move:

- It cannot be an `import`, because a bundled module is deferred — which is the flash it exists to prevent.
- It cannot take a `src`, because that puts a blocking request in front of the paint it is trying to get ahead of.

Inlining it from a file with `?raw` and `set:html` *does* work — I checked, and it would even save about 100 bytes a page, since the file's indentation is shallower than the `.astro` nesting. It was not worth it: the comment above that script explains why it must be inline and pre-paint, and moving the code away from that reasoning makes the subtle part easier to break. `?raw` also injects verbatim, so the file has to stay plain `.js` forever or it ships broken TypeScript to the browser with nothing to catch it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
