### PR TITLE
feat: lay out the latest blog posts as cards

### DIFF
--- a/src/pages/blog.astro
+++ b/src/pages/blog.astro
@@ -27,28 +27,33 @@ const posts = recentPosts();
             opening it. */}
         <h2 class="h4 mb-3">Latest Posts</h2>
 
-        {/* Unstyled because the markers would sit oddly against multi-line
-            entries; each post is a heading and a paragraph, not a bullet. */}
+        {/* One card per post, stacked full width, the same shape the FAQ's
+            questions take. Unstyled because a marker would sit outside the box
+            entirely, level with the border rather than with the text it belongs
+            to. The card class goes on the <li> itself; a wrapper inside it
+            would only repeat what the list item already is. */}
         <ul class="list-unstyled">
           {
             posts.map((post) => (
-              <li class="mb-4">
-                <h3 class="h5 mb-1">
-                  <a href={post.url}>{post.title}</a>
-                </h3>
-                {/* The middot carries its own padding because the compiler
-                    strips the whitespace between adjacent elements, the same
-                    way the footer's separator does. */}
-                <p class="text-muted small mb-1">
-                  <time datetime={post.dateISO}>{post.date}</time>
-                  {post.author && (
-                    <>
-                      <span class="px-1">&middot;</span>
-                      {post.author}
-                    </>
-                  )}
-                </p>
-                {post.summary && <p class="mb-0">{post.summary}</p>}
+              <li class="card mb-3">
+                <div class="card-body">
+                  <h3 class="card-title mb-1">
+                    <a href={post.url}>{post.title}</a>
+                  </h3>
+                  {/* The middot carries its own padding because the compiler
+                      strips the whitespace between adjacent elements, the same
+                      way the footer's separator does. */}
+                  <p class="text-muted small mb-1">
+                    <time datetime={post.dateISO}>{post.date}</time>
+                    {post.author && (
+                      <>
+                        <span class="px-1">&middot;</span>
+                        {post.author}
+                      </>
+                    )}
+                  </p>
+                  {post.summary && <p class="card-text mb-0">{post.summary}</p>}
+                </div>
               </li>
             ))
           }


### PR DESCRIPTION
Puts each of the three latest posts on `/blog/` in a card, stacked full width. It was the last listing on the site rendered as bare text: `/documentation`, `/contribute`, `/vscode`, `/principles` and `/faq` all put their items in a box, and this page did not.

The shape is the FAQ's — `FAQ/QA.astro` is a `.card mb-3` per question — rather than a three-across grid like `/contribute`'s Projects row. The grid fills the width better with summaries this short, but it would be tied to the post count: `recentPosts()` defaults to three (`blogPosts.js`), and raising that to four would leave a row of three plus an orphan. A stack takes any number.

## What the markup does

The card class goes on the `<li>` itself. A wrapper `<div class="card">` inside the item would only restate what the list item already is, and `.card` is `display: flex` in Bootstrap, so the element carrying it stops being a marker box either way.

The heading moves from `.h5` to `.card-title`, which is what every other card on the site labels itself with (`vscode.astro`, `contribute.astro`). It resolves to 1.2rem through `global.css` instead of Bootstrap's 1.25rem — 0.05rem smaller, and now one class rather than a heading level chosen by eye. `mb-1` still overrides the title's own spacer so the date line stays tucked under it, and the summary picks up `.card-text`.

The date, the author, and the middot that separates them are untouched.

## No CSS

`.card` resolves to `--bs-body-bg`, the same surface `.page` paints, so a card here is a hairline border and padding rather than a second background colour. Nothing to define, and dark mode was already covered by the border and body tokens.

The comment above the list is rewritten: `list-unstyled` was there because markers sat oddly against multi-line entries, and the reason is now that a marker would sit outside the box entirely, level with the border instead of the text it belongs to.

## Checked

`npx astro build` passes and the emitted `/blog/index.html` carries the intended structure. The dark-mode claim above is read off the tokens, not off a screenshot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
