### PR TITLE
fix: stop the GitHub ribbon covering the theme toggle

### DIFF
--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -167,10 +167,19 @@ import '../styles/global.css';
       <header>
         {/* The ribbon is absolutely positioned against the viewport, so its
             place in the DOM only affects the reading order, not the layout.
-            Hidden below the navbar's breakpoint, where it would claim the same
-            149px of top-right corner that the collapsed navbar puts its
-            toggler in. */}
-        <a class="d-none d-lg-block" href="https://github.com/flix/flix">
+            What it does claim is the top-right corner, which is also where the
+            navbar ends, and the whole 149px square is inside the link - so
+            wherever the two meet, the ribbon swallows the clicks meant for the
+            theme toggle rather than merely sitting over it.
+
+            They stop meeting once the margin beside the card, (viewport -
+            container) / 2, clears the ribbon's 149px less the 28px of navbar
+            and container padding the toggle already sits inside: 121px, so
+            from viewport = container + 242px up. The container is held at
+            1140px above, which puts that at 1382px and makes xxl the first
+            breakpoint where the ribbon fits - by 9px, and by more from there
+            on, since that cap stops the container growing to meet it. */}
+        <a class="d-none d-xxl-block" href="https://github.com/flix/flix">
           <img style="position: absolute; top: 0; right: 0; border: 0; z-index: 9999;"
               src="/forkme_right_green_007200.png"
               alt="Fork me on GitHub">


### PR DESCRIPTION
The "Fork me on GitHub" ribbon is 149px wide and pinned to the top-right of the viewport at `z-index: 9999` — the same corner the navbar ends in. It was shown from `lg` up.

It only clears the theme toggle once the margin beside the page card, `(viewport - container) / 2`, exceeds the ribbon's 149px less the 28px of navbar and container padding the toggle already sits inside: 121px, so from `viewport = container + 242px`. Against the 1140px the container is capped at, that is 1382px.

Below that the ribbon sat on top of the toggle — and since the whole 149px square is inside the `<a>`, it took the clicks meant for it, so the toggle was unreachable on an ordinary 1280 or 1366 laptop. Below 1200px, where the container drops to 960px, it reached "Internships" as well.

`d-none d-xxl-block` is the first breakpoint past the threshold, clearing it by 9px — and by more from there on, since the 1140px cap in `global.css` stops the container growing to meet it. That dependency is noted in the comment above the ribbon.

Not addressed here: between 992px and 1199px the nav row needs ~1030px against a 960px container, so "Get Started" still wraps to two lines. Separate change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)