### PR TITLE
chore: upgrade astro to 7.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,10 +13,10 @@
         "@iconify-json/fa-brands": "^1.2.2",
         "@iconify-json/fa-solid": "^1.2.2",
         "@iconify-json/mdi": "^1.2.3",
-        "@iconify-json/octicon": "^1.2.29",
+        "@iconify-json/octicon": "^1.2.32",
         "@iconify-json/simple-icons": "^1.2.91",
         "@shikijs/themes": "^4.4.1",
-        "astro": "^7.0.3",
+        "astro": "^7.2.0",
         "astro-icon": "^1.1.5",
         "bootstrap": "^5.3.8"
       },
@@ -1186,9 +1186,9 @@
       }
     },
     "node_modules/@iconify-json/octicon": {
-      "version": "1.2.30",
-      "resolved": "https://registry.npmjs.org/@iconify-json/octicon/-/octicon-1.2.30.tgz",
-      "integrity": "sha512-6wi8HjjRTKlZ/2BBoQIT00vur67Onr86NSpRqbELsegowjea+L2oEbvtiisc/EhRvMlh3GWIdEfhqyFuPZcd5g==",
+      "version": "1.2.32",
+      "resolved": "https://registry.npmjs.org/@iconify-json/octicon/-/octicon-1.2.32.tgz",
+      "integrity": "sha512-gkb+HMhBxZzVvOQhs4NZg0AtMJ8uht6bc8fG757gDOpXjjAOcNe2KrJDd8ydGVmRZoNBIexJAovz8b+no4oTuA==",
       "license": "MIT",
       "dependencies": {
         "@iconify/types": "*"
@@ -2116,28 +2116,6 @@
       "integrity": "sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==",
       "license": "MIT"
     },
-    "node_modules/@rollup/pluginutils": {
-      "version": "5.4.0",
-      "resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-5.4.0.tgz",
-      "integrity": "sha512-MfPp06CjRLfXQ3wY0R8vJDYBy/MvVcc9OulEfR0B8Iv9ko+GCNaRZ+EpJYFl27LhKsZK0o420sYCRHCjfCgeUg==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/estree": "^1.0.0",
-        "estree-walker": "^2.0.2",
-        "picomatch": "^4.0.2"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      },
-      "peerDependencies": {
-        "rollup": "^1.20.0||^2.0.0||^3.0.0||^4.0.0"
-      },
-      "peerDependenciesMeta": {
-        "rollup": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/@shikijs/core": {
       "version": "4.4.1",
       "resolved": "https://registry.npmjs.org/@shikijs/core/-/core-4.4.1.tgz",
@@ -2574,9 +2552,9 @@
       }
     },
     "node_modules/astro": {
-      "version": "7.1.6",
-      "resolved": "https://registry.npmjs.org/astro/-/astro-7.1.6.tgz",
-      "integrity": "sha512-83x9rYbHazMaZkYrAFRVZXSQx2moFkz0F7cjTDUF3GWfS0a3p2vZXG1ZdhV86rStHApQCodBJW+XTD37xISIrQ==",
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/astro/-/astro-7.2.0.tgz",
+      "integrity": "sha512-lLTYzx3fOvCmtwD3JVBLQcbORbIOW1/j0R+3IvJx/XKwMGrk7mFnF0BYSOeRiNw1qHUR5mdA6+hRnyvyDfqrWQ==",
       "license": "MIT",
       "dependencies": {
         "@astrojs/compiler-rs": "^0.3.2",
@@ -2586,7 +2564,6 @@
         "@capsizecss/unpack": "^4.0.0",
         "@clack/prompts": "^1.1.0",
         "@oslojs/encoding": "^1.1.0",
-        "@rollup/pluginutils": "^5.3.0",
         "am-i-vibing": "^0.4.0",
         "aria-query": "^5.3.2",
         "axobject-query": "^4.1.0",
@@ -3263,12 +3240,6 @@
       "engines": {
         "node": ">=6"
       }
-    },
-    "node_modules/estree-walker": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
-      "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
-      "license": "MIT"
     },
     "node_modules/eventemitter3": {
       "version": "5.0.4",

--- a/package.json
+++ b/package.json
@@ -11,10 +11,10 @@
     "@iconify-json/fa-brands": "^1.2.2",
     "@iconify-json/fa-solid": "^1.2.2",
     "@iconify-json/mdi": "^1.2.3",
-    "@iconify-json/octicon": "^1.2.29",
+    "@iconify-json/octicon": "^1.2.32",
     "@iconify-json/simple-icons": "^1.2.91",
     "@shikijs/themes": "^4.4.1",
-    "astro": "^7.0.3",
+    "astro": "^7.2.0",
     "astro-icon": "^1.1.5",
     "bootstrap": "^5.3.8"
   },


### PR DESCRIPTION
Upgrades `astro` to 7.2.0 and `@iconify-json/octicon` to 1.2.32.

Worth noting up front that this is a smaller step than the version ranges suggest: `^7.0.3` was already resolving forward to 7.1.6, so the real move is 7.1.6 → 7.2.0, one minor. Same for octicon — `^1.2.29` was on 1.2.30.

## The lockfile delta

Only two packages change version, and two transitive ones drop out:

| | before | after |
|---|---|---|
| `astro` | 7.1.6 | 7.2.0 |
| `@iconify-json/octicon` | 1.2.30 | 1.2.32 |
| `@rollup/pluginutils` | 5.4.0 | removed |
| `estree-walker` | 2.0.2 | removed |

`vite` stays at 8.2.0 — 7.2.0 asks for `^8.0.13` and the tree was already above that. Astro's `engines.node` is unchanged at `>=22.12.0`, so the `>=22` in `package.json` and the 22.x/24.x CI matrix are both still fine.

## Nothing to migrate

7.2.0 has no breaking changes and no deprecations. Its minor entries are all opt-in and none apply here: a `session: false` switch for trimming session code out of SSR bundles, `experimental.incrementalBuild`, a `digest` property for content-layer loaders, relative-path resolution for the logger entrypoint, and a widened `AstroPrerenderer.render()` return type. This site is static with no sessions, no content collections, and no custom logger or prerenderer, so `astro.config.mjs` is untouched.

The patch fixes are more relevant on paper — one of them corrects `Astro.url.pathname` formatting — but nothing here read that value, and the build output confirms nothing moved.

## @shikijs/themes is deliberately left alone

4.4.3 is out and `^4.4.1` would have taken it, but taking it is a regression. Astro 7.2.0 pins `shiki@4.4.1`, which carries its own `@shikijs/themes` — so at `^4.4.1` the two dedupe to one copy, and at `^4.4.3` they split:

```
node_modules/@shikijs/themes            4.4.3   <- what CodeSnippet.astro imports
node_modules/shiki/.../@shikijs/themes  4.4.1   <- what Astro's shiki uses
```

That is 1.8M duplicated, and it hands 4.4.3 theme objects to a 4.4.1 highlighter. `CodeSnippet.astro` already notes that `shiki` resolves only through astro, and this is the other half of that: the theme range wants to track whatever shiki version astro ships, not run ahead of it. I built it both ways — the output is identical either way, so the newer themes buy nothing to offset the skew. It picks up 4.4.3 on its own once astro bumps shiki.

## Checked

`npm run check` is clean across 26 files, and `npm run build` emits the same 10 pages plus the sitemap.

Beyond that, the whole of `dist/` diffs byte-for-byte identical against a build from before the upgrade — so the one octicon in use (`octicon:graph-24`, on `/documentation`) and the light-plus/dark-plus highlighting both render exactly as they did. The dev server was smoke-tested separately: `/`, `/faq/`, `/vscode/`, `/blog/`, `/get-started/` and `/principles/` all 200.

## Not addressed here

Two things I found and left:

- **`nanoid` GHSA-2v37-7h3g-55p8** (high), reached through `astro -> vite -> postcss`. It is pre-existing — 3.3.16 is in the lockfile on `master` today — and unrelated to this upgrade, which neither caused nor fixed it. `npm audit fix` resolves it as a nested bump.
- **TypeScript 6.0.3 → 7.0.2**, a major, which deserves its own pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
