### PR TITLE
feat: add a whole-program optimizing compiler section to the front page

### DIFF
--- a/src/lib/indexExamples.js
+++ b/src/lib/indexExamples.js
@@ -364,3 +364,44 @@ export const datalogExample = `def reachable(g: List[(String, Int32, String)], m
         Path(x, z) :- Path(x, y), Road(y, maxSpeed, z), if maxSpeed >= minSpeed.
     };
     query facts, rules select (src, dst) from Path(src, dst) |> Foldable.toList`;
+
+export const optimizerExample = `/// Sums \`f\` applied to every element of \`arr\`.
+/// Polymorphic in \`a\`, higher-order in \`f\`, and
+/// generic over the region \`r\` the array lives in.
+def sumWith(f: a -> Int32, arr: Array[a, r]): Int32 \\ r =
+    Array.foldLeft((acc, x) -> acc + f(x), 0, arr)
+
+def main(): Unit \\ IO =
+    region rc {
+        let arr = Array#{1, 2, 3, 4, 5} @ rc;
+        println(sumWith(x -> x * x, arr))
+    }`;
+
+export const optimizerBytecode = `static Result$ staticApply(int[], int, int, int);
+   0: iload_2
+   1: iload_1
+   2: if_icmplt    9
+   5: iconst_1
+   6: goto         10
+   9: iconst_0
+  10: ifne         40         // i >= len: done
+  13: aload_0
+  14: iload_2
+  15: iaload                  // x = arr[i], unboxed
+  16: istore       4
+  18: aload_0
+  19: iload_1
+  20: iload_2
+  21: iconst_1
+  22: iadd                    // i + 1
+  23: iload_3                 // acc
+  24: iload        4
+  26: iload        4
+  28: imul                    // f(x) => x * x
+  29: iadd                    // acc + f(x)
+  30: istore_3
+  31: istore_2
+  32: istore_1
+  33: astore_0
+  34: goto         0          // a loop, not a call
+  40: iload_3                 // return acc`;

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -820,7 +820,7 @@ const vscodeSlides = [
           Flix is a whole-program optimizing compiler. It uses
           monomorphization, inlining, closure elimination, tail call
           elimination, and aggressive tree shaking to turn high-level code into
-          tight low-level code. Write code in whatever style you prefer &mdash;
+          tight low-level code. Write code in whatever style you prefer* &mdash;
           generic, higher-order, split into many small functions &mdash;
           without paying for it at runtime.
         </p>
@@ -853,6 +853,7 @@ const vscodeSlides = [
             &mdash; only loads, stores, arithmetic, and branches.
           </li>
         </ul>
+        <p class="small text-muted">*: Some terms and conditions apply.</p>
       </div>
       <div class="col-md-6">
         <h5>What the JVM runs</h5>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -811,6 +811,68 @@ const vscodeSlides = [
 
     <hr class="mb-4" />
 
+    <div class="row mb-4">
+      <div class="col-md-12">
+        <h2>An Optimizing Compiler</h2>
+        <p>
+          Flix compiles to JVM bytecode through an optimizing pipeline. The
+          aim is that you can write in whatever style reads best &mdash;
+          generic, higher-order, split into many small functions &mdash;
+          without paying for it at runtime:
+        </p>
+        <ul>
+          <li>
+            <b>Monomorphization</b> &mdash; a generic function is compiled
+            separately for each type it is actually used at. A <code
+              >List[Int32]</code
+            > holds real unboxed integers, and a trait method call is an ordinary
+            direct call rather than a lookup at runtime.
+          </li>
+          <li>
+            <b>Inlining</b> &mdash; small functions and lambdas are copied into
+            the code that calls them, so you can break a computation into as
+            many little helpers as you like. The compiler keeps track of where
+            each expression is used, so inlining never turns one piece of work
+            into two.
+          </li>
+          <li>
+            <b>Dead code elimination</b> &mdash; if you compute a pure value
+            and then never use it, the computation is removed. Bindings that
+            merely rename another variable disappear as well.
+          </li>
+          <li>
+            <b>Compile-time pattern matching</b> &mdash; when the compiler
+            already knows which case a value is, it chooses the branch while
+            compiling and deletes the ones that can never be taken.
+          </li>
+          <li>
+            <b>Lambda dropping</b> &mdash; a recursive function that carries a
+            function argument around stops passing it along on every call,
+            since that argument never changes.
+          </li>
+          <li>
+            <b>Tree shaking</b> &mdash; functions you never call, including
+            those in the libraries you depend on, are left out of the generated
+            code entirely.
+          </li>
+          <li>
+            <b>Tail call elimination</b> &mdash; a function that calls itself
+            as its last step becomes a loop, and any other call in tail
+            position runs without growing the stack. Recursive code does not
+            overflow.
+          </li>
+        </ul>
+        <p>
+          All of this rests on the effect system: because the compiler knows
+          exactly which expressions are pure, it knows which ones it may safely
+          move, copy, or delete &mdash; and which ones it must leave precisely
+          where you wrote them.
+        </p>
+      </div>
+    </div>
+
+    <hr class="mb-4" />
+
     <div class="row">
       <div class="col-12 mb-3">
         <h2>Visual Studio Code Support</h2>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -820,6 +820,8 @@ const vscodeSlides = [
           generic, higher-order, split into many small functions &mdash;
           without paying for it at runtime:
         </p>
+      </div>
+      <div class="col-md-6">
         <ul>
           <li>
             <b>Monomorphization</b> &mdash; a generic function is compiled
@@ -840,6 +842,10 @@ const vscodeSlides = [
             and then never use it, the computation is removed. Bindings that
             merely rename another variable disappear as well.
           </li>
+        </ul>
+      </div>
+      <div class="col-md-6">
+        <ul>
           <li>
             <b>Compile-time pattern matching</b> &mdash; when the compiler
             already knows which case a value is, it chooses the branch while
@@ -862,6 +868,8 @@ const vscodeSlides = [
             overflow.
           </li>
         </ul>
+      </div>
+      <div class="col-md-12">
         <p>
           All of this rests on the effect system: because the compiler knows
           exactly which expressions are pure, it knows which ones it may safely

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -29,6 +29,8 @@ import {
   manifestExample,
   manifestOutput,
   datalogExample,
+  optimizerExample,
+  optimizerBytecode,
 } from "../lib/indexExamples.js";
 
 const vscodeSlides = [
@@ -813,68 +815,52 @@ const vscodeSlides = [
 
     <div class="row mb-4">
       <div class="col-md-12">
-        <h2>An Optimizing Compiler</h2>
+        <h2>A Whole-Program Optimizing Compiler</h2>
         <p>
-          Flix compiles to JVM bytecode through an optimizing pipeline. The
-          aim is that you can write in whatever style reads best &mdash;
+          Flix is a whole-program optimizing compiler. It uses
+          monomorphization, inlining, closure elimination, tail call
+          elimination, and aggressive tree shaking to turn high-level code into
+          tight low-level code. Write code in whatever style you prefer &mdash;
           generic, higher-order, split into many small functions &mdash;
-          without paying for it at runtime:
+          without paying for it at runtime.
         </p>
       </div>
+
       <div class="col-md-6">
-        <ul>
+        <h5>What you write</h5>
+        <CodeSnippet code={optimizerExample} />
+        <ul class="mt-3">
           <li>
-            <b>Monomorphization</b> &mdash; a generic function is compiled
-            separately for each type it is actually used at. A <code
-              >List[Int32]</code
-            > holds real unboxed integers, and a trait method call is an ordinary
-            direct call rather than a lookup at runtime.
+            <b>No closure allocation.</b> Neither <code>sumWith</code> nor the
+            lambda <code>x -&gt; x * x</code> survives as a closure. Both are
+            inlined, and the compiler emits no closure class for either.
           </li>
           <li>
-            <b>Inlining</b> &mdash; small functions and lambdas are copied into
-            the code that calls them, so you can break a computation into as
-            many little helpers as you like. The compiler keeps track of where
-            each expression is used, so inlining never turns one piece of work
-            into two.
+            <b>No recursion.</b> <code>Array.foldLeft</code> is written recursively,
+            but nothing calls itself here: the fold is a counted loop that ends
+            in <code>goto 0</code>.
           </li>
           <li>
-            <b>Dead code elimination</b> &mdash; if you compute a pure value
-            and then never use it, the computation is removed. Bindings that
-            merely rename another variable disappear as well.
+            <b>No boxing.</b> The loop takes a bare <code>int[]</code> and three
+            raw <code>int</code>s. Elements are read off the array with <code
+              >iaload</code
+            >, and the index and accumulator never leave the stack. Only the final
+            result is boxed.
+          </li>
+          <li>
+            <b>No dispatch.</b> The call to <code>f</code> is one <code>imul</code
+            >. The loop body contains no method call and no allocation at all
+            &mdash; only loads, stores, arithmetic, and branches.
           </li>
         </ul>
       </div>
       <div class="col-md-6">
-        <ul>
-          <li>
-            <b>Compile-time pattern matching</b> &mdash; when the compiler
-            already knows which case a value is, it chooses the branch while
-            compiling and deletes the ones that can never be taken.
-          </li>
-          <li>
-            <b>Lambda dropping</b> &mdash; a recursive function that carries a
-            function argument around stops passing it along on every call,
-            since that argument never changes.
-          </li>
-          <li>
-            <b>Tree shaking</b> &mdash; functions you never call, including
-            those in the libraries you depend on, are left out of the generated
-            code entirely.
-          </li>
-          <li>
-            <b>Tail call elimination</b> &mdash; a function that calls itself
-            as its last step becomes a loop, and any other call in tail
-            position runs without growing the stack. Recursive code does not
-            overflow.
-          </li>
-        </ul>
-      </div>
-      <div class="col-md-12">
-        <p>
-          All of this rests on the effect system: because the compiler knows
-          exactly which expressions are pure, it knows which ones it may safely
-          move, copy, or delete &mdash; and which ones it must leave precisely
-          where you wrote them.
+        <h5>What the JVM runs</h5>
+        <PlainSnippet code={optimizerBytecode} />
+        <p class="small text-muted mt-3">
+          Reproduce with <code>flix build</code> followed by <code
+            >javap -c -p</code
+          >; the listing above elides only the trailing boxing of the result.
         </p>
       </div>
     </div>


### PR DESCRIPTION
Adds a section to the front page showing what the compiler does to the code it generates — built around a worked example and the bytecode actually emitted for it, rather than a list of claims.

## The figure

```flix
def sumWith(f: a -> Int32, arr: Array[a, r]): Int32 \ r =
    Array.foldLeft((acc, x) -> acc + f(x), 0, arr)

def main(): Unit \ IO =
    region rc {
        let arr = Array#{1, 2, 3, 4, 5} @ rc;
        println(sumWith(x -> x * x, arr))
    }
```

A polymorphic, higher-order fold over a mutable array in a region compiles to a 34-byte counted loop taking a bare `int[]` and three raw `int`s, with the lambda reduced to a single `imul` and the recursion to `goto 0`.

Every claim beside the listing was verified against a real build with `flix` 0.75.2:

- **No closure allocation** — no `Clo$main$*` class is emitted at all, so neither `sumWith` nor the lambda survives as a closure.
- **No recursion** — `Array.foldLeft` is recursive; the emitted code ends in `goto 0`.
- **No boxing** — the loop signature is `(int[], int, int, int)`; only the final result is boxed.
- **No dispatch** — the loop body's entire opcode inventory is loads, stores, arithmetic and branches. No `invoke`, `new`, or `newarray`.

The listing elides only the trailing boxing of the result. The loop body has no constant-pool references at all, so it is otherwise verbatim `javap` output plus comments, reproducible with `flix build` followed by `javap -c -p`.

## Placement and framing

It sits after "Compiler Performance: The Raw Numbers", so the compiler region reads architecture → compiler speed → generated-code quality. That section already claims the compiler is fast *"despite supporting costly features, including monomorphization and whole-program optimization"* without ever saying what those are; the new section's title and lead now name them.

## How the example was chosen

Three variants were built and disassembled before settling on the region-based one:

| | classes | jar | loop signature | allocation in loop |
|---|---|---|---|---|
| `List` | 172 | 83K | `(int, Tagged$)` | none in the fold |
| `Vector` | 169 | 80K | `(int, int, int)` | **`newarray` every iteration** |
| region `Array` | 165 | 78K | `(int[], int, int, int)` | none |

The region version wins on every axis, and earns a claim the others can't: the region has no runtime representation in the loop — `main` allocates a `Region$`, but the loop receives a plain array.
